### PR TITLE
Rename `device.*` extras so `pip` can find them

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3370,14 +3370,14 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-clients = ["flask", "pydantic", "pyjwt", "python-dotenv", "pytz", "requests", "strenum", "tzlocal"]
-devices-dht22 = ["pigpio"]
-devices-epd = ["pillow", "rpi.gpio", "spidev"]
-devices-yamaha-yas-209 = ["async-upnp-client", "pydantic", "xmltodict"]
+clients = ["flask", "pydantic", "pyjwt", "python-dotenv", "requests", "strenum", "tzlocal"]
+dht22 = ["pigpio"]
+epd = ["pillow", "rpi.gpio", "spidev"]
 exceptions = ["python-dotenv", "requests"]
 functions = ["lxml"]
+yamaha-yas-209 = ["async-upnp-client", "pydantic", "xmltodict"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "33471f4533f547bd4ed6154b6345999bc0ecc9339e780eb4daf911fd161a6546"
+content-hash = "238a787ef3240fa8c25b19cbc0875f8d4108f4ed336921778d6b1763319cf809"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,17 +76,16 @@ clients = [
     "flask",
     "pyjwt",
     "requests",
-    "pytz",
     "tzlocal",
     "pydantic",
     "python-dotenv",
     "strenum",
 ]
-"devices.epd" = ["spidev", "rpi.gpio", "Pillow"]
-"devices.dht22" = ["pigpio"]
-"devices.yamaha_yas_209" = ["async-upnp-client", "pydantic", "xmltodict"]
-"exceptions" = ["python-dotenv", "requests"]
-"functions" = ["lxml"]
+epd = ["spidev", "rpi.gpio", "Pillow"]
+dht22 = ["pigpio"]
+yamaha_yas_209 = ["async-upnp-client", "pydantic", "xmltodict"]
+exceptions = ["python-dotenv", "requests"]
+functions = ["lxml"]
 
 
 # Tool Configs


### PR DESCRIPTION
`pip install wg-utilities[devices.yamaha_yas_209]` doesn't work but `pip install wg-utilities[exceptions]` does, so the `.` in the extra name must be causing some kind of issue. Hopefully.