### PR TITLE
Stop songs with ampersands in from breaking the XML parser

### DIFF
--- a/tests/flat_files/json/google/calendar/v3/calendars/google-user@gmail.com/events/maxresults=500&orderby=updated&singleevents=true&pagetoken=abc.json
+++ b/tests/flat_files/json/google/calendar/v3/calendars/google-user@gmail.com/events/maxresults=500&orderby=updated&singleevents=true&pagetoken=abc.json
@@ -29762,7 +29762,7 @@
       "creator": {
         "email": "kuocxr.tpsxizmcc@fwnbzljr.oz"
       },
-      "description": "Good Morning Domenico,<br><br>Further to your recent interview for our Software Development Manager opportunity, we would like to invite you to the next stage of the process:<br><br><b>Interview Date:&nbsp; Thursday 13th October</b><br><b>Interview Time:&nbsp; 9am</b><br><b>Interviewers:&nbsp; &nbsp; &nbsp; Sergei Bagdasar, Google User &amp; Lucas Rijllart</b><br><br>The call will be held via Google Meet, link included.<br>If you require anything else in advance feel free to contact me.<br><br>Many Thanks<br>Hayley&nbsp;",
+      "description": "",
       "end": {
         "dateTime": "2022-10-13T09:30:00+01:00",
         "timeZone": "Europe/London"

--- a/tests/flat_files/json/google/calendar/v3/calendars/google-user@gmail.com/events/maxresults=500&orderby=updated&singleevents=true.json
+++ b/tests/flat_files/json/google/calendar/v3/calendars/google-user@gmail.com/events/maxresults=500&orderby=updated&singleevents=true.json
@@ -10673,7 +10673,7 @@
       "creator": {
         "email": "kuocxr.tpsxizmcc@fwnbzljr.oz"
       },
-      "description": "Good Afternoon Alex,<br><br>Further to your recent application for our Python Developer opportunity, we would like to invite you to interview with us:<br><br><b>Interview Date:&nbsp; &nbsp; &nbsp;Wednesday 11th May</b><br><b>Interview Time:&nbsp; &nbsp; 12pm</b><br><b>Interviewers:&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Google User &amp; Lucas Rijllart</b><br><br>The interview will be held via Google Hangouts, link included. If you require anything else in advance feel free to contact me.<br><br>Many Thanks<br>Hayley",
+      "description": "",
       "end": {
         "dateTime": "2022-05-11T12:30:00+01:00",
         "timeZone": "Europe/London"

--- a/tests/flat_files/xml/yamaha_yas_209/event_payloads/av_transport/payload_20230408232348755378.xml
+++ b/tests/flat_files/xml/yamaha_yas_209/event_payloads/av_transport/payload_20230408232348755378.xml
@@ -1,0 +1,46 @@
+<Event xmlns="urn:schemas-upnp-org:metadata-1-0/AVT/">
+    <InstanceID val="0">
+        <TransportState val="PLAYING"/>
+        <TransportStatus val="OK"/>
+        <NumberOfTracks val="0"/>
+        <CurrentTrack val="0"/>
+        <CurrentTrackDuration val="00:04:11"/>
+        <CurrentMediaDuration val="00:04:11"/>
+        <CurrentTrackURI val="spotify:track:0qc9orA9xxAVePx8L0X4o3"/>
+        <AVTransportURI val="spotify:track:0qc9orA9xxAVePx8L0X4o3"/>
+        <CurrentTrackMetaData val="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;DIDL-Lite xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot; xmlns:upnp=&quot;urn:schemas-upnp-org:metadata-1-0/upnp/&quot; xmlns:song=&quot;www.wiimu.com/song/&quot; xmlns=&quot;urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/&quot;&gt;
+&lt;upnp:class&gt;object.item.audioItem.musicTrack&lt;/upnp:class&gt;
+&lt;item id=&quot;0&quot;&gt;
+&lt;song:subid&gt;Chill Electronica&lt;/song:subid&gt;
+&lt;song:description&gt;&lt;/song:description&gt;
+&lt;song:skiplimit&gt;0&lt;/song:skiplimit&gt;
+&lt;song:id&gt;0qc9orA9xxAVePx8L0X4o3&lt;/song:id&gt;
+&lt;song:like&gt;0&lt;/song:like&gt;
+&lt;song:singerid&gt;0&lt;/song:singerid&gt;
+&lt;song:albumid&gt;0&lt;/song:albumid&gt;
+&lt;res protocolInfo=&quot;http-get:*:audio/mpeg:DLNA.ORG_PN=MP3;DLNA.ORG_OP=01;&quot; duration=&quot;00:04:11.000&quot;&gt;spotify:track:0qc9orA9xxAVePx8L0X4o3&lt;/res&gt;
+&lt;dc:title&gt;You &amp; I&lt;/dc:title&gt;
+&lt;dc:creator&gt;JANEVA&lt;/dc:creator&gt;
+&lt;upnp:artist&gt;JANEVA&lt;/upnp:artist&gt;
+&lt;upnp:album&gt;You &amp; I&lt;/upnp:album&gt;
+&lt;upnp:albumArtURI&gt;https://i.scdn.co/image/ab67616d0000b27309a28b2d82b709193c8d5dde&lt;/upnp:albumArtURI&gt;
+&lt;/item&gt;
+&lt;/DIDL-Lite&gt;
+"/>9
+        <PlaybackStorageMedium val="SPOTIFY"/>
+        <PossiblePlaybackStorageMedia val="NONE,STATION-NETWORK,SONGLIST-NETWORK,SONGLIST-LOCAL,SONGLIST-LOCAL_TF,THIRD-DLNA,AIRPLAY,UNKNOWN"/>
+        <PossibleRecordStorageMedia val="NOT_IMPLEMENTED"/>
+        <RecordStorageMedium val="NOT_IMPLEMENTED"/>
+        <CurrentPlayMode val="NORMAL"/>
+        <TransportPlaySpeed val="1"/>
+        <RecordMediumWriteStatus val="NOT_IMPLEMENTED"/>
+        <CurrentRecordQualityMode val="NOT_IMPLEMENTED"/>
+        <PossibleRecordQualityModes val="NOT_IMPLEMENTED"/>
+        <RelativeTimePosition val="00:03:17"/>
+        <AbsoluteTimePosition val="NOT_IMPLEMENTED"/>
+        <RelativeCounterPosition val="-1"/>
+        <AbsoluteCounterPosition val="-1"/>
+        <CurrentTransportActions val="Stop,Seek,X_DLNA_SeekTime,Pause"/>
+    </InstanceID>
+</Event>

--- a/tests/unit/devices/yamaha_yas_209/test__yamaha_yas_209.py
+++ b/tests/unit/devices/yamaha_yas_209/test__yamaha_yas_209.py
@@ -378,6 +378,25 @@ def test_on_event_wrapper_parses_xml_dicts(
 
 
 @mark.upnp_value_path(  # type: ignore[misc]
+    # You & I by JANEVA
+    FLAT_FILES_DIR
+    / "xml"
+    / "yamaha_yas_209"
+    / "event_payloads"
+    / "av_transport"
+    / "payload_20230408232348755378.xml"
+)
+def test_xml_payloads_with_ampersands_can_be_parsed(
+    yamaha_yas_209: YamahaYas209,
+    upnp_service_av_transport: UpnpService,
+    upnp_state_variable: UpnpStateVariable,
+) -> None:
+    """Test that a song with an ampersand in the title can be parsed."""
+
+    yamaha_yas_209.on_event_wrapper(upnp_service_av_transport, [upnp_state_variable])
+
+
+@mark.upnp_value_path(  # type: ignore[misc]
     # Obvs by Jamie XX
     FLAT_FILES_DIR
     / "xml"

--- a/wg_utilities/devices/yamaha_yas_209/yamaha_yas_209.py
+++ b/wg_utilities/devices/yamaha_yas_209/yamaha_yas_209.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from functools import wraps
 from logging import DEBUG, getLogger
+from re import compile as re_compile
 from textwrap import dedent
 from threading import Thread
 from time import sleep, strptime
@@ -872,11 +873,14 @@ class YamahaYas209:
         Args:
             xml_dict (dict): the dictionary to parse
         """
+
+        pattern = re_compile(r"&(?!(amp|apos|lt|gt|quot);)")
+
         traverse_dict(
             xml_dict,
             target_type=str,
             target_processor_func=lambda val, dict_key=None, list_index=None: parse_xml(
-                val, attr_prefix="", cdata_key="text"
+                pattern.sub("&amp;", val), attr_prefix="", cdata_key="text"
             ),
             single_keys_to_remove=["val", "DIDL-Lite"],
         )


### PR DESCRIPTION
For some reason, the first/"outer" pass of `parse_xml` incorrectly unescapes the ampersands within the nested XML; this change uses regex to re-replace them with the escaped version.

The following is an example payload which breaks the YAS-209's XML parsing capability. Note specifically the `You &amp; I` values.

```xml
<Event xmlns="urn:schemas-upnp-org:metadata-1-0/AVT/">
    <InstanceID val="0">
        <TransportState val="PLAYING"/>
        <TransportStatus val="OK"/>
        <NumberOfTracks val="0"/>
        <CurrentTrack val="0"/>
        <CurrentTrackDuration val="00:04:11"/>
        <CurrentMediaDuration val="00:04:11"/>
        <CurrentTrackURI val="spotify:track:0qc9orA9xxAVePx8L0X4o3"/>
        <AVTransportURI val="spotify:track:0qc9orA9xxAVePx8L0X4o3"/>
        <CurrentTrackMetaData val="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
&lt;DIDL-Lite xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot; xmlns:upnp=&quot;urn:schemas-upnp-org:metadata-1-0/upnp/&quot; xmlns:song=&quot;www.wiimu.com/song/&quot; xmlns=&quot;urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/&quot;&gt;
&lt;upnp:class&gt;object.item.audioItem.musicTrack&lt;/upnp:class&gt;
&lt;item id=&quot;0&quot;&gt;
&lt;song:subid&gt;Chill Electronica&lt;/song:subid&gt;
&lt;song:description&gt;&lt;/song:description&gt;
&lt;song:skiplimit&gt;0&lt;/song:skiplimit&gt;
&lt;song:id&gt;0qc9orA9xxAVePx8L0X4o3&lt;/song:id&gt;
&lt;song:like&gt;0&lt;/song:like&gt;
&lt;song:singerid&gt;0&lt;/song:singerid&gt;
&lt;song:albumid&gt;0&lt;/song:albumid&gt;
&lt;res protocolInfo=&quot;http-get:*:audio/mpeg:DLNA.ORG_PN=MP3;DLNA.ORG_OP=01;&quot; duration=&quot;00:04:11.000&quot;&gt;spotify:track:0qc9orA9xxAVePx8L0X4o3&lt;/res&gt;
&lt;dc:title&gt;You &amp; I&lt;/dc:title&gt;
&lt;dc:creator&gt;JANEVA&lt;/dc:creator&gt;
&lt;upnp:artist&gt;JANEVA&lt;/upnp:artist&gt;
&lt;upnp:album&gt;You &amp; I&lt;/upnp:album&gt;
&lt;upnp:albumArtURI&gt;https://i.scdn.co/image/ab67616d0000b27309a28b2d82b709193c8d5dde&lt;/upnp:albumArtURI&gt;
&lt;/item&gt;
&lt;/DIDL-Lite&gt;
"/>9
        <PlaybackStorageMedium val="SPOTIFY"/>
        <PossiblePlaybackStorageMedia val="NONE,STATION-NETWORK,SONGLIST-NETWORK,SONGLIST-LOCAL,SONGLIST-LOCAL_TF,THIRD-DLNA,AIRPLAY,UNKNOWN"/>
        <PossibleRecordStorageMedia val="NOT_IMPLEMENTED"/>
        <RecordStorageMedium val="NOT_IMPLEMENTED"/>
        <CurrentPlayMode val="NORMAL"/>
        <TransportPlaySpeed val="1"/>
        <RecordMediumWriteStatus val="NOT_IMPLEMENTED"/>
        <CurrentRecordQualityMode val="NOT_IMPLEMENTED"/>
        <PossibleRecordQualityModes val="NOT_IMPLEMENTED"/>
        <RelativeTimePosition val="00:03:17"/>
        <AbsoluteTimePosition val="NOT_IMPLEMENTED"/>
        <RelativeCounterPosition val="-1"/>
        <AbsoluteCounterPosition val="-1"/>
        <CurrentTransportActions val="Stop,Seek,X_DLNA_SeekTime,Pause"/>
    </InstanceID>
</Event>
```