### PR TITLE
Add refresh interval to Spotify User playlists attribute

### DIFF
--- a/tests/unit/clients/spotify/test__user.py
+++ b/tests/unit/clients/spotify/test__user.py
@@ -749,3 +749,30 @@ def test_reset_properties(
                 mock_requests.reset_mock()
                 getattr(spotify_user, prop_name)
                 assert mock_requests.call_count == 0
+
+
+def test_playlist_refresh_time(spotify_user: User, mock_requests: Mocker) -> None:
+    """Test that `playlist` property refreshes after 15 minutes."""
+
+    assert not mock_requests.request_history
+
+    with freeze_time(frozen_time := datetime.utcnow()):
+        assert not hasattr(spotify_user, "_playlist_refresh_time")
+        _ = spotify_user.playlists
+
+    assert spotify_user._playlist_refresh_time == frozen_time
+
+    # There are 4 pages for the test Playlist response
+    assert len(mock_requests.request_history) == 4
+
+    with freeze_time(frozen_time + timedelta(minutes=14, seconds=59)):
+        _ = spotify_user.playlists
+        assert spotify_user._playlist_refresh_time == frozen_time
+
+    assert len(mock_requests.request_history) == 4
+
+    with freeze_time(new_frozen_time := frozen_time + timedelta(minutes=15, seconds=1)):
+        _ = spotify_user.playlists
+        assert spotify_user._playlist_refresh_time == new_frozen_time
+
+    assert len(mock_requests.request_history) == 8

--- a/tests/unit/clients/spotify/test__user.py
+++ b/tests/unit/clients/spotify/test__user.py
@@ -765,13 +765,13 @@ def test_playlist_refresh_time(spotify_user: User, mock_requests: Mocker) -> Non
     # There are 4 pages for the test Playlist response
     assert len(mock_requests.request_history) == 4
 
-    with freeze_time(frozen_time + timedelta(minutes=14, seconds=59)):
+    with freeze_time(frozen_time + timedelta(minutes=9, seconds=59)):
         _ = spotify_user.playlists
         assert spotify_user._playlist_refresh_time == frozen_time
 
     assert len(mock_requests.request_history) == 4
 
-    with freeze_time(new_frozen_time := frozen_time + timedelta(minutes=15, seconds=1)):
+    with freeze_time(new_frozen_time := frozen_time + timedelta(minutes=10, seconds=1)):
         _ = spotify_user.playlists
         assert spotify_user._playlist_refresh_time == new_frozen_time
 

--- a/wg_utilities/clients/spotify.py
+++ b/wg_utilities/clients/spotify.py
@@ -1192,6 +1192,8 @@ class Playlist(SpotifyEntity[PlaylistSummaryJson]):
 class User(SpotifyEntity[UserSummaryJson]):
     """A Spotify user, usually just the current user."""
 
+    PLAYLIST_REFRESH_INTERVAL: ClassVar[timedelta] = timedelta(minutes=10)
+
     display_name: str
     country: str | None
     email: str | None
@@ -1497,9 +1499,11 @@ class User(SpotifyEntity[UserSummaryJson]):
             list: a list of playlists owned by the current user
         """
 
-        if hasattr(self, "_playlist_refresh_time") and (
-            datetime.utcnow() - self._playlist_refresh_time
-        ) < timedelta(minutes=15):
+        if (
+            hasattr(self, "_playlist_refresh_time")
+            and (datetime.utcnow() - self._playlist_refresh_time)
+            < self.PLAYLIST_REFRESH_INTERVAL
+        ):
             return self._playlists
 
         self._set_private_attr("_playlist_refresh_time", datetime.utcnow())


### PR DESCRIPTION
- Add refresh interval to Spotify User `playlists` attribute
- Refactor refresh interval to be class attribute
