### PR TITLE
Fix deprecations from Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ log_cli_level = "warning"
 pythonpath = ["wg_utilities"]
 testpaths = ["tests"]
 env = []
-filterwarnings = ["ignore::DeprecationWarning:boto.*:"]
+filterwarnings = ["ignore::DeprecationWarning:dateutil.tz:37"]
 markers = [
   "mocked_operation_lookup: allows setting the mocks in the `mb3c` fixture",
   "upnp_value_path: file with content to set as the value in a `upnp_state_variable` fixture",

--- a/tests/unit/clients/monzo/test__account.py
+++ b/tests/unit/clients/monzo/test__account.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from urllib.parse import urlencode
 
@@ -173,7 +173,7 @@ def test_update_balance_variables(monzo_account: Account, mock_requests: Mocker)
     with freeze_time():
         monzo_account.update_balance_variables()
 
-        assert monzo_account.last_balance_update == datetime.utcnow()
+        assert monzo_account.last_balance_update == datetime.now(UTC)
 
     assert monzo_account.balance_variables.model_dump() == {
         "balance": 177009,

--- a/tests/unit/clients/oauth_client/test__oauth_client.py
+++ b/tests/unit/clients/oauth_client/test__oauth_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from json import loads
 from pathlib import Path
@@ -62,7 +62,7 @@ def test_oauth_credentials_parse_first_time_login_attributes(
     assert creds.client_secret == "test_client_secret"
     assert creds.is_expired is False
 
-    with freeze_time(datetime.utcnow() + timedelta(seconds=3600)):
+    with freeze_time(datetime.now(UTC) + timedelta(seconds=3600)):
         assert creds.is_expired is True
 
 
@@ -75,7 +75,7 @@ def test_oauth_credentials_parse_first_time_login_expiry_mismatch() -> None:
                 "access_token": "test_access_token",
                 "refresh_token": "test_refresh_token",
                 # This is after the JWT token expiry
-                "expiry": ((datetime.utcnow() + timedelta(seconds=3700)).isoformat()),
+                "expiry": ((datetime.now(UTC) + timedelta(seconds=3700)).isoformat()),
                 "expires_in": 3600,
                 "scope": "test_scope",
                 "token_type": "Bearer",
@@ -84,7 +84,7 @@ def test_oauth_credentials_parse_first_time_login_expiry_mismatch() -> None:
 
     assert fullmatch(
         r"^`expiry` and `expires_in` are not consistent with each other: expiry:"
-        r" \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3,6}, expires_in: \d+\.?\d*$",
+        r" \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3,6}\+00:00, expires_in: \d+\.?\d*$",
         str(exc_info.value),
     )
 

--- a/tests/unit/clients/spotify/conftest.py
+++ b/tests/unit/clients/spotify/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for the Spotify client tests."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from pathlib import Path
 from re import IGNORECASE
@@ -139,7 +139,7 @@ def spotify_playlist_(spotify_client: SpotifyClient) -> Playlist:
     )
 
     playlist._live_snapshot_id = playlist.snapshot_id
-    playlist._live_snapshot_id_timestamp = datetime.utcnow() + timedelta(hours=21)
+    playlist._live_snapshot_id_timestamp = datetime.now(UTC) + timedelta(hours=21)
 
     return playlist
 

--- a/tests/unit/clients/spotify/test__playlist.py
+++ b/tests/unit/clients/spotify/test__playlist.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from os import listdir
 
 import pytest
@@ -238,7 +238,7 @@ def test_live_snapshot_id(
     assert not hasattr(spotify_playlist_alt, "_live_snapshot_id")
     assert not hasattr(spotify_playlist_alt, "_live_snapshot_id_timestamp")
 
-    with freeze_time(frozen_time := datetime.utcnow()):
+    with freeze_time(frozen_time := datetime.now(UTC)):
         # Because a different value is in the `fields=snapshot_id.json` stub
         assert spotify_playlist_alt.live_snapshot_id != spotify_playlist_alt.snapshot_id
 
@@ -318,7 +318,7 @@ def test_tracks_property_updates_snapshot_id(
 
     # After a minute the only call should be to check the snapshot ID
 
-    with freeze_time(frozen_time := datetime.utcnow() + timedelta(minutes=1)):
+    with freeze_time(frozen_time := datetime.now(UTC) + timedelta(minutes=1)):
         _ = spotify_playlist_alt.tracks
 
     assert spotify_playlist_alt._live_snapshot_id_timestamp == frozen_time

--- a/tests/unit/clients/spotify/test__user.py
+++ b/tests/unit/clients/spotify/test__user.py
@@ -1,7 +1,7 @@
 """Unit Tests for `wg_utilities.clients.spotify.User`."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from typing import Literal
 from unittest.mock import patch
@@ -174,11 +174,11 @@ def test_get_recently_liked_tracks_day_limit(
     assert all(isinstance(track, Track) for track in result)
     assert all(track.spotify_client == spotify_client for track in result)
     assert all(
-        track.metadata["saved_at"] > datetime.utcnow() - timedelta(days=7)
+        track.metadata["saved_at"] > datetime.now(UTC) - timedelta(days=7)
         for track in result
     )
     assert not any(
-        track.metadata["saved_at"] <= datetime.utcnow() - timedelta(days=7)
+        track.metadata["saved_at"] <= datetime.now(UTC) - timedelta(days=7)
         for track in result
     )
 
@@ -751,7 +751,7 @@ def test_playlist_refresh_time(spotify_user: User, mock_requests: Mocker) -> Non
 
     assert not mock_requests.request_history
 
-    with freeze_time(frozen_time := datetime.utcnow()):
+    with freeze_time(frozen_time := datetime.now(UTC)):
         assert not hasattr(spotify_user, "_playlist_refresh_time")
         _ = spotify_user.playlists
 

--- a/tests/unit/clients/truelayer/test__truelayer_entity.py
+++ b/tests/unit/clients/truelayer/test__truelayer_entity.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from typing import Literal
 from unittest.mock import call, patch
@@ -84,7 +84,7 @@ def test_update_balance_values(account: Account) -> None:
     assert not hasattr(account, "_current_balance")
     assert not hasattr(account, "_overdraft")
 
-    with freeze_time(frozen_datetime := datetime.utcnow()):
+    with freeze_time(frozen_datetime := datetime.now(UTC)):
         account.update_balance_values()
 
     assert not hasattr(account, "_available_balance")
@@ -164,7 +164,7 @@ def test_get_balance_property_account(
             mock_update_balance_values.assert_called_once()
 
             # Third call should trigger updates because we're now outside the threshold
-            account.last_balance_update = datetime.utcnow() - timedelta(hours=1e6)
+            account.last_balance_update = datetime.now(UTC) - timedelta(hours=1e6)
             _ = account._get_balance_property(property_name)
 
             assert mock_update_balance_values.call_count == 2
@@ -219,7 +219,7 @@ def test_get_balance_property_card(
             mock_update_balance_values.assert_called_once()
 
             # Third call should trigger updates because we're now outside the threshold
-            card.last_balance_update = datetime.utcnow() - timedelta(hours=1e6)
+            card.last_balance_update = datetime.now(UTC) - timedelta(hours=1e6)
             _ = card._get_balance_property(property_name)
 
             assert mock_update_balance_values.call_count == 2

--- a/tests/unit/devices/yamaha_yas_209/test__yamaha_yas_209.py
+++ b/tests/unit/devices/yamaha_yas_209/test__yamaha_yas_209.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from asyncio import new_event_loop
 from collections.abc import Mapping
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 from http import HTTPStatus
 from logging import DEBUG, ERROR, INFO, WARNING
 from textwrap import dedent
@@ -694,8 +694,8 @@ def test_on_event_callback_called_correctly(
         yamaha_yas_209._parse_xml_dict(something_else_value)  # type: ignore[arg-type]
 
         assert payload == {
-            # This whole test has frozen time, so we can just use `datetime.utcnow()`
-            "timestamp": datetime.utcnow(),
+            # This whole test has frozen time, so we can just use `datetime.now(UTC)`
+            "timestamp": datetime.now(UTC),
             "service_id": upnp_service_rendering_control.service_id,
             "service_type": upnp_service_rendering_control.service_type,
             # The last change will be a `LastChange` instance

--- a/tests/unit/loggers/conftest.py
+++ b/tests/unit/loggers/conftest.py
@@ -274,3 +274,9 @@ def mock_requests_(
     )
 
     return mock_requests_root
+
+
+@pytest.fixture(autouse=True)
+def _mock_atexit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fixture for mocking atexit.register."""
+    monkeypatch.setattr("atexit.register", lambda *_, **__: None)

--- a/tests/unit/loggers/test__list_handler.py
+++ b/tests/unit/loggers/test__list_handler.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from logging import Logger, LogRecord, getLevelName
 from unittest.mock import MagicMock, patch
 
@@ -102,7 +102,7 @@ def test_expire_records_remove_records_correctly(
 
     for i in range(-1, 25):
         with freeze_time(BASE_TIME + timedelta(seconds=i * 5)):
-            message = f"Created at {datetime.utcnow()}. Valid: {i >= 12}"
+            message = f"Created at {datetime.now(UTC)}. Valid: {i >= 12}"
             logger.info(message)
 
     with freeze_time(BASE_TIME):
@@ -112,7 +112,7 @@ def test_expire_records_remove_records_correctly(
         assert record.created >= (BASE_TIME.timestamp() + 60)
         assert (
             record.msg
-            == f"Created at {datetime.fromtimestamp(record.created)}. Valid: True"
+            == f"Created at {datetime.fromtimestamp(record.created, tz=UTC)}. Valid: True"
         )
 
 

--- a/tests/unit/testing/_custom_mocks/test__mock_boto3_client.py
+++ b/tests/unit/testing/_custom_mocks/test__mock_boto3_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from os import environ
 from unittest.mock import patch
 
@@ -348,7 +348,7 @@ def test_non_mocked_calls_still_go_to_aws(
     with patch(
         MockBoto3Client.PATCH_METHOD,
         mb3c.build_api_call(),
-    ), freeze_time(frozen_time := datetime.utcnow().replace(microsecond=0)):
+    ), freeze_time(frozen_time := datetime.now(UTC).replace(microsecond=0)):
         s3_client.create_bucket(
             Bucket="test-bucket",
             CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
@@ -421,7 +421,7 @@ def test_non_moto_supported_operations_raise_exception(
     with patch(
         MockBoto3Client.PATCH_METHOD,
         mb3c.build_api_call(),
-    ), freeze_time(frozen_time := datetime.utcnow().replace(microsecond=0)):
+    ), freeze_time(frozen_time := datetime.now(UTC).replace(microsecond=0)):
         # Prove moto is working
         res = pinpoint_client.create_app(
             CreateApplicationRequest={

--- a/wg_utilities/api/temp_auth_server.py
+++ b/wg_utilities/api/temp_auth_server.py
@@ -1,11 +1,9 @@
 """Provide a class for creating a temporary server during an authentication flow."""
-
 from __future__ import annotations
 
-from datetime import datetime
 from textwrap import dedent
 from threading import Thread
-from time import sleep
+from time import sleep, time
 from typing import Any, cast
 
 from flask import Flask, Response, request
@@ -151,9 +149,9 @@ class TempAuthServer:
         if not self.is_running:
             self.start_server()
 
-        start_time = datetime.utcnow()
+        start_time = time()
         while (
-            time_elapsed := (datetime.utcnow() - start_time).seconds
+            time_elapsed := time() - start_time
         ) <= max_wait and not self._request_args.get(endpoint):
             sleep(0.5)
 

--- a/wg_utilities/clients/google_calendar.py
+++ b/wg_utilities/clients/google_calendar.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from datetime import UTC, timedelta, tzinfo
 from datetime import date as date_
 from datetime import datetime as datetime_
-from datetime import timedelta, tzinfo
 from enum import StrEnum
 from typing import Any, ClassVar, Literal, Self, TypeAlias
 
 from pydantic import Field, field_serializer, field_validator, model_validator
-from pytz import UTC, timezone
+from pytz import timezone
 from requests import delete
 from typing_extensions import NotRequired, TypedDict
 from tzlocal import get_localzone

--- a/wg_utilities/clients/monzo.py
+++ b/wg_utilities/clients/monzo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from logging import DEBUG, getLogger
 from typing import Any, ClassVar, Literal, final
 
@@ -293,9 +293,9 @@ class Account(BaseModelWithConfig):
         """
 
         from_datetime = (
-            from_datetime or (datetime.utcnow() - timedelta(days=89))
+            from_datetime or (datetime.now(UTC) - timedelta(days=89))
         ).replace(microsecond=0, tzinfo=None)
-        to_datetime = (to_datetime or datetime.utcnow()).replace(
+        to_datetime = (to_datetime or datetime.now(UTC)).replace(
             microsecond=0,
             tzinfo=None,
         )
@@ -323,7 +323,7 @@ class Account(BaseModelWithConfig):
         """
 
         if not hasattr(self, "_balance_variables") or self.last_balance_update <= (
-            datetime.utcnow() - timedelta(minutes=self.balance_update_threshold)
+            datetime.now(UTC) - timedelta(minutes=self.balance_update_threshold)
         ):
             LOGGER.debug("Balance variable update threshold crossed, getting new values")
 
@@ -331,7 +331,7 @@ class Account(BaseModelWithConfig):
                 self.monzo_client.get_json_response(f"/balance?account_id={self.id}"),
             )
 
-            self.last_balance_update = datetime.utcnow()
+            self.last_balance_update = datetime.now(UTC)
 
     @property
     def balance(self) -> int | None:

--- a/wg_utilities/clients/spotify.py
+++ b/wg_utilities/clients/spotify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from builtins import dict as dict_
 from builtins import type as type_
 from collections.abc import Callable, Iterable, Iterator, Sequence
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from http import HTTPStatus
 from json import dumps
@@ -1004,7 +1004,7 @@ class Playlist(SpotifyEntity[PlaylistSummaryJson]):
         if (
             not hasattr(self, "_live_snapshot_id_timestamp")
             or not hasattr(self, "_live_snapshot_id")
-            or datetime.utcnow() - self._live_snapshot_id_timestamp > timedelta(minutes=1)
+            or datetime.now(UTC) - self._live_snapshot_id_timestamp > timedelta(minutes=1)
         ):
             self._live_snapshot_id = self.spotify_client.get_json_response(
                 f"/playlists/{self.id}",
@@ -1013,7 +1013,7 @@ class Playlist(SpotifyEntity[PlaylistSummaryJson]):
                 "snapshot_id"  # type: ignore[typeddict-item]
             ]
 
-            self._live_snapshot_id_timestamp = datetime.utcnow()
+            self._live_snapshot_id_timestamp = datetime.now(UTC)
 
         return self._live_snapshot_id
 
@@ -1233,8 +1233,8 @@ class User(SpotifyEntity[UserSummaryJson]):
                     datetime.strptime(
                         item["added_at"],
                         self.spotify_client.DATETIME_FORMAT,
-                    )
-                    < (datetime.utcnow() - timedelta(days=day_limit)),
+                    ).replace(tzinfo=UTC)
+                    < (datetime.now(UTC) - timedelta(days=day_limit)),
                 )
 
         return [
@@ -1245,7 +1245,7 @@ class User(SpotifyEntity[UserSummaryJson]):
                     "saved_at": datetime.strptime(
                         item["added_at"],
                         self.spotify_client.DATETIME_FORMAT,
-                    ),
+                    ).replace(tzinfo=UTC),
                 },
             )
             for item in cast(
@@ -1456,12 +1456,12 @@ class User(SpotifyEntity[UserSummaryJson]):
 
         if (
             hasattr(self, "_playlist_refresh_time")
-            and (datetime.utcnow() - self._playlist_refresh_time)
+            and (datetime.now(UTC) - self._playlist_refresh_time)
             < self.PLAYLIST_REFRESH_INTERVAL
         ):
             return self._playlists
 
-        self._playlist_refresh_time = datetime.utcnow()
+        self._playlist_refresh_time = datetime.now(UTC)
 
         all_playlist_json = cast(
             list[PlaylistSummaryJson],
@@ -1551,7 +1551,7 @@ class User(SpotifyEntity[UserSummaryJson]):
                         "saved_at": datetime.strptime(
                             item["added_at"],
                             self.spotify_client.DATETIME_FORMAT,
-                        ),
+                        ).replace(tzinfo=UTC),
                     },
                 )
                 for item in cast(

--- a/wg_utilities/clients/truelayer.py
+++ b/wg_utilities/clients/truelayer.py
@@ -1,9 +1,8 @@
 """Custom client for interacting with TrueLayer's API."""
-
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from enum import Enum, StrEnum, auto
 from logging import DEBUG, getLogger
 from pathlib import Path
@@ -233,8 +232,8 @@ class TrueLayerEntity(BaseModelWithConfig):
         """
 
         if from_datetime or to_datetime:
-            from_datetime = from_datetime or datetime.utcnow() - timedelta(days=90)
-            to_datetime = to_datetime or datetime.utcnow()
+            from_datetime = from_datetime or datetime.now(UTC) - timedelta(days=90)
+            to_datetime = to_datetime or datetime.now(UTC)
 
             params: (
                 dict[
@@ -302,7 +301,7 @@ class TrueLayerEntity(BaseModelWithConfig):
 
             setattr(self, attr_name, v)
 
-        self.last_balance_update = datetime.utcnow()
+        self.last_balance_update = datetime.now(UTC)
 
     @overload
     def _get_balance_property(
@@ -367,7 +366,7 @@ class TrueLayerEntity(BaseModelWithConfig):
             not hasattr(self, f"_{prop_name}")
             or getattr(self, f"_{prop_name}") is None
             or self.last_balance_update
-            <= (datetime.utcnow() - self.balance_update_threshold)
+            <= (datetime.now(UTC) - self.balance_update_threshold)
         ):
             self.update_balance_values()
 

--- a/wg_utilities/devices/yamaha_yas_209/yamaha_yas_209.py
+++ b/wg_utilities/devices/yamaha_yas_209/yamaha_yas_209.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from asyncio import new_event_loop, run
 from asyncio import sleep as async_sleep
 from collections.abc import Callable, Coroutine, Mapping, MutableMapping, Sequence
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from functools import wraps
 from logging import DEBUG, getLogger
@@ -691,7 +691,7 @@ class YamahaYas209:
         )
 
         event_payload: YamahaYas209.EventPayloadInfo = {
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(UTC),
             "service_id": service.service_id,
             "service_type": service.service_type,
             "last_change": last_change,

--- a/wg_utilities/functions/datetime_helpers.py
+++ b/wg_utilities/functions/datetime_helpers.py
@@ -1,12 +1,9 @@
 """Helper functions for all things date and time related."""
-
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import overload
-
-from pytz import utc
 
 
 class DatetimeFixedUnit(Enum):
@@ -52,9 +49,9 @@ def utcnow(unit: DatetimeFixedUnit | None = None) -> datetime | int:
     """
 
     if not unit:
-        return datetime.utcnow().replace(tzinfo=utc)
+        return datetime.now(UTC)
 
-    return int(datetime.utcnow().replace(tzinfo=utc).timestamp() / unit.value)
+    return int(datetime.now(UTC).timestamp() / unit.value)
 
 
 __all__ = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved efficiency and accuracy in time calculations across various modules by standardizing the use of `UTC` for datetime operations.
- **Chore**
	- Adjusted and reorganized import statements related to datetime handling for consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->