### PR TITLE
Remove `python-dotenv` dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
           - mypy_boto3_s3
           - pydantic==2.6.1
           - pytest==8.0.1
-          - python-dotenv==1.0.1
           - requests-mock==1.11.0
           - types-Pillow
           - types-PyYAML

--- a/poetry.lock
+++ b/poetry.lock
@@ -1557,20 +1557,6 @@ files = [
 defusedxml = ">=0.6.0"
 
 [[package]]
-name = "python-dotenv"
-version = "1.0.1"
-description = "Read key-value pairs from a .env file and set them as environment variables"
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
-    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
-]
-
-[package.extras]
-cli = ["click (>=5.0)"]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -1595,7 +1581,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1973,11 +1958,11 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [extras]
-clients = ["flask", "pydantic", "pyjwt", "python-dotenv", "requests", "tzlocal"]
+clients = ["flask", "pydantic", "pyjwt", "requests", "tzlocal"]
 devices-dht22 = ["pigpio"]
 devices-epd = ["pillow", "rpi.gpio", "spidev"]
 devices-yamaha-yas-209 = ["async-upnp-client", "pydantic", "xmltodict"]
-exceptions = ["python-dotenv", "requests"]
+exceptions = ["requests"]
 functions = ["lxml"]
 logging = ["requests"]
 testing = ["botocore"]
@@ -1985,4 +1970,4 @@ testing = ["botocore"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d85aac24a95a7ca74683095f8041fca294e2e4d1b96458c49277148a017fa509"
+content-hash = "21c580a3c297edc86f148d78114769ffa27df936780441e7243aceaab35d413d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ lxml = { version = "==5.1.0", optional = true }
 pigpio = { version = "*", optional = true }
 pillow = { version = "*", optional = true }
 pyjwt = { version = ">=2.6,<2.9", optional = true }
-python-dotenv = { version = "*", optional = true }
 requests = { version = ">=2.26.0", optional = true }
 "rpi.gpio" = { version = "*", platform = "linux", optional = true }
 spidev = { version = "*", platform = "linux", optional = true }
@@ -61,12 +60,11 @@ clients = [
   "requests",
   "tzlocal",
   "pydantic",
-  "python-dotenv",
 ]
 "devices.epd" = ["spidev", "rpi.gpio", "Pillow"]
 "devices.dht22" = ["pigpio"]
 "devices.yamaha_yas_209" = ["async-upnp-client", "pydantic", "xmltodict"]
-"exceptions" = ["python-dotenv", "requests"]
+"exceptions" = ["requests"]
 "logging" = ["requests"]
 "functions" = ["lxml"]
 "testing" = ["botocore"]

--- a/wg_utilities/exceptions/_deprecated.py
+++ b/wg_utilities/exceptions/_deprecated.py
@@ -10,7 +10,6 @@ from sys import exc_info
 from traceback import format_exc
 from typing import TYPE_CHECKING, Any
 
-from dotenv import load_dotenv
 from requests import post
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -19,7 +18,6 @@ from wg_utilities.loggers import add_stream_handler
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-load_dotenv()
 
 HA_LOG_ENDPOINT = getenv("HA_LOG_ENDPOINT", "homeassistant.local:8001")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed deprecated environment variable initialization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->