### PR TITLE
Add `get_top_tracks` method to Spotify client

### DIFF
--- a/.vscode/wg-utilities.code-workspace
+++ b/.vscode/wg-utilities.code-workspace
@@ -39,7 +39,10 @@
 		"launches": {
 			"PythonCurrentFile": "Python: Current File",
 		},
-		"python.testing.autoTestDiscoverOnSaveEnabled": true
+		"python.testing.autoTestDiscoverOnSaveEnabled": true,
+		"cSpell.words": [
+			"AUDIOBOOK"
+		]
 	},
 	"launch": {
 		"version": "0.2.0",

--- a/.vscode/wg-utilities.code-workspace
+++ b/.vscode/wg-utilities.code-workspace
@@ -9,10 +9,6 @@
 		{
 			"path": "/Users/worgarside/Library/Application Support/WgUtilities/"
 		},
-        {
-            "name": "SSH FS - /config",
-            "uri": "ssh://hasspi-config/config"
-        },
 	],
 	"settings": {
 		"python.testing.unittestEnabled": false,

--- a/tests/flat_files/json/spotify/v1/me/top/tracks/time_range=long_term&limit=50.json
+++ b/tests/flat_files/json/spotify/v1/me/top/tracks/time_range=long_term&limit=50.json
@@ -1,0 +1,4350 @@
+{
+  "href": "https://api.spotify.com/v1/me/top/tracks?limit=50&offset=0&time_range=short_term",
+  "items": [
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+            "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+            "name": "venbee",
+            "type": "artist",
+            "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tfGcCoLFmUtfhgB9sREHq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tfGcCoLFmUtfhgB9sREHq",
+            "id": "4tfGcCoLFmUtfhgB9sREHq",
+            "name": "Dan Fable",
+            "type": "artist",
+            "uri": "spotify:artist:4tfGcCoLFmUtfhgB9sREHq"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/48KWh33PB86WJeyFhQOkVl"
+        },
+        "href": "https://api.spotify.com/v1/albums/48KWh33PB86WJeyFhQOkVl",
+        "id": "48KWh33PB86WJeyFhQOkVl",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2736e0759c0137223701e4f4c3b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e026e0759c0137223701e4f4c3b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048516e0759c0137223701e4f4c3b",
+            "width": 64
+          }
+        ],
+        "name": "low down",
+        "release_date": "2022-05-23",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:48KWh33PB86WJeyFhQOkVl"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+          "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+          "name": "venbee",
+          "type": "artist",
+          "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4tfGcCoLFmUtfhgB9sREHq"
+          },
+          "href": "https://api.spotify.com/v1/artists/4tfGcCoLFmUtfhgB9sREHq",
+          "id": "4tfGcCoLFmUtfhgB9sREHq",
+          "name": "Dan Fable",
+          "type": "artist",
+          "uri": "spotify:artist:4tfGcCoLFmUtfhgB9sREHq"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 182923,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "QZES92294424"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5hwQBJojbljFjxg7t49r03"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5hwQBJojbljFjxg7t49r03",
+      "id": "5hwQBJojbljFjxg7t49r03",
+      "is_local": false,
+      "name": "low down",
+      "popularity": 67,
+      "preview_url": "https://p.scdn.co/mp3-preview/9af09320dc7793d2c5eb373b7374ca10db145385?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5hwQBJojbljFjxg7t49r03"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+            "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+            "name": "venbee",
+            "type": "artist",
+            "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3yDDYheQFqfhKZXdjFQuuP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3yDDYheQFqfhKZXdjFQuuP",
+            "id": "3yDDYheQFqfhKZXdjFQuuP",
+            "name": "goddard.",
+            "type": "artist",
+            "uri": "spotify:artist:3yDDYheQFqfhKZXdjFQuuP"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0a9uNlopPXGg37OC20qDk6"
+        },
+        "href": "https://api.spotify.com/v1/albums/0a9uNlopPXGg37OC20qDk6",
+        "id": "0a9uNlopPXGg37OC20qDk6",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27302402656bca0b5b39489f39a",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0202402656bca0b5b39489f39a",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485102402656bca0b5b39489f39a",
+            "width": 64
+          }
+        ],
+        "name": "messy in heaven",
+        "release_date": "2022-09-23",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:0a9uNlopPXGg37OC20qDk6"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+          "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+          "name": "venbee",
+          "type": "artist",
+          "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3yDDYheQFqfhKZXdjFQuuP"
+          },
+          "href": "https://api.spotify.com/v1/artists/3yDDYheQFqfhKZXdjFQuuP",
+          "id": "3yDDYheQFqfhKZXdjFQuuP",
+          "name": "goddard.",
+          "type": "artist",
+          "uri": "spotify:artist:3yDDYheQFqfhKZXdjFQuuP"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 170437,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBARL2201891"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5RobAV5ROH5KARimi7n3cO"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5RobAV5ROH5KARimi7n3cO",
+      "id": "5RobAV5ROH5KARimi7n3cO",
+      "is_local": false,
+      "name": "messy in heaven",
+      "popularity": 76,
+      "preview_url": "https://p.scdn.co/mp3-preview/39f0684b09b7b6e48c93f1fc9f89b2fdec8cef22?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5RobAV5ROH5KARimi7n3cO"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4frXpPxQQZwbCu3eTGnZEw"
+            },
+            "href": "https://api.spotify.com/v1/artists/4frXpPxQQZwbCu3eTGnZEw",
+            "id": "4frXpPxQQZwbCu3eTGnZEw",
+            "name": "Thundercat",
+            "type": "artist",
+            "uri": "spotify:artist:4frXpPxQQZwbCu3eTGnZEw"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/7vHBQDqwzB7uDvoE5bncMM"
+        },
+        "href": "https://api.spotify.com/v1/albums/7vHBQDqwzB7uDvoE5bncMM",
+        "id": "7vHBQDqwzB7uDvoE5bncMM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27385c5e6c686ced3e43bae2748",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0285c5e6c686ced3e43bae2748",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485185c5e6c686ced3e43bae2748",
+            "width": 64
+          }
+        ],
+        "name": "Drunk",
+        "release_date": "2017-02-24",
+        "release_date_precision": "day",
+        "total_tracks": 23,
+        "type": "album",
+        "uri": "spotify:album:7vHBQDqwzB7uDvoE5bncMM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4frXpPxQQZwbCu3eTGnZEw"
+          },
+          "href": "https://api.spotify.com/v1/artists/4frXpPxQQZwbCu3eTGnZEw",
+          "id": "4frXpPxQQZwbCu3eTGnZEw",
+          "name": "Thundercat",
+          "type": "artist",
+          "uri": "spotify:artist:4frXpPxQQZwbCu3eTGnZEw"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 188453,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "US25X1090547"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7CH99b2i1TXS5P8UUyWtnM"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7CH99b2i1TXS5P8UUyWtnM",
+      "id": "7CH99b2i1TXS5P8UUyWtnM",
+      "is_local": false,
+      "name": "Them Changes",
+      "popularity": 79,
+      "preview_url": "https://p.scdn.co/mp3-preview/c9a76d20b277680af25d9b920cb03a2412135003?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 15,
+      "type": "track",
+      "uri": "spotify:track:7CH99b2i1TXS5P8UUyWtnM"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+            "id": "5gqoUf9vKKv96b1c0GBKwu",
+            "name": "Dusky",
+            "type": "artist",
+            "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1zJORUI9CgL3QHBhRqy0OM"
+        },
+        "href": "https://api.spotify.com/v1/albums/1zJORUI9CgL3QHBhRqy0OM",
+        "id": "1zJORUI9CgL3QHBhRqy0OM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273eb6412542b6e16fc44261405",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02eb6412542b6e16fc44261405",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851eb6412542b6e16fc44261405",
+            "width": 64
+          }
+        ],
+        "name": "Lonely Dulcimer / In Effect",
+        "release_date": "2022-09-16",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:1zJORUI9CgL3QHBhRqy0OM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+          },
+          "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+          "id": "5gqoUf9vKKv96b1c0GBKwu",
+          "name": "Dusky",
+          "type": "artist",
+          "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 193741,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205190"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5vY3kwXfrDxNu8XzsbMhZi"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5vY3kwXfrDxNu8XzsbMhZi",
+      "id": "5vY3kwXfrDxNu8XzsbMhZi",
+      "is_local": false,
+      "name": "Lonely Dulcimer",
+      "popularity": 42,
+      "preview_url": "https://p.scdn.co/mp3-preview/535d9dc0e39d2a975617454328eb930ea2842e0f?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5vY3kwXfrDxNu8XzsbMhZi"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0iTjLBepeGaLgZS18kxgRq"
+            },
+            "href": "https://api.spotify.com/v1/artists/0iTjLBepeGaLgZS18kxgRq",
+            "id": "0iTjLBepeGaLgZS18kxgRq",
+            "name": "Oliver Schories",
+            "type": "artist",
+            "uri": "spotify:artist:0iTjLBepeGaLgZS18kxgRq"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5wMlMjOLeJfS5DfxqGfm83"
+            },
+            "href": "https://api.spotify.com/v1/artists/5wMlMjOLeJfS5DfxqGfm83",
+            "id": "5wMlMjOLeJfS5DfxqGfm83",
+            "name": "Jan Blomqvist",
+            "type": "artist",
+            "uri": "spotify:artist:5wMlMjOLeJfS5DfxqGfm83"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2N1lWGpmve4vfMTGeCk3At"
+        },
+        "href": "https://api.spotify.com/v1/albums/2N1lWGpmve4vfMTGeCk3At",
+        "id": "2N1lWGpmve4vfMTGeCk3At",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273844cab1b3286d8b06e219311",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02844cab1b3286d8b06e219311",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851844cab1b3286d8b06e219311",
+            "width": 64
+          }
+        ],
+        "name": "Packard",
+        "release_date": "2020-06-19",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:2N1lWGpmve4vfMTGeCk3At"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0iTjLBepeGaLgZS18kxgRq"
+          },
+          "href": "https://api.spotify.com/v1/artists/0iTjLBepeGaLgZS18kxgRq",
+          "id": "0iTjLBepeGaLgZS18kxgRq",
+          "name": "Oliver Schories",
+          "type": "artist",
+          "uri": "spotify:artist:0iTjLBepeGaLgZS18kxgRq"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5wMlMjOLeJfS5DfxqGfm83"
+          },
+          "href": "https://api.spotify.com/v1/artists/5wMlMjOLeJfS5DfxqGfm83",
+          "id": "5wMlMjOLeJfS5DfxqGfm83",
+          "name": "Jan Blomqvist",
+          "type": "artist",
+          "uri": "spotify:artist:5wMlMjOLeJfS5DfxqGfm83"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 361281,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "DEY472083912"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/68UiApRTyu4Trb5kwMgCd2"
+      },
+      "href": "https://api.spotify.com/v1/tracks/68UiApRTyu4Trb5kwMgCd2",
+      "id": "68UiApRTyu4Trb5kwMgCd2",
+      "is_local": false,
+      "name": "Packard - Blomqvist & Schories Sunrise Mix",
+      "popularity": 45,
+      "preview_url": "https://p.scdn.co/mp3-preview/3fe9da983900e01de2a292e69b84a05f28146124?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:68UiApRTyu4Trb5kwMgCd2"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+            "id": "5gqoUf9vKKv96b1c0GBKwu",
+            "name": "Dusky",
+            "type": "artist",
+            "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6QEnHZniqvybsckdyptQql"
+        },
+        "href": "https://api.spotify.com/v1/albums/6QEnHZniqvybsckdyptQql",
+        "id": "6QEnHZniqvybsckdyptQql",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2737a9e1bfb1e953cab106ac9e1",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e027a9e1bfb1e953cab106ac9e1",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048517a9e1bfb1e953cab106ac9e1",
+            "width": 64
+          }
+        ],
+        "name": "Pressure",
+        "release_date": "2022-10-07",
+        "release_date_precision": "day",
+        "total_tracks": 11,
+        "type": "album",
+        "uri": "spotify:album:6QEnHZniqvybsckdyptQql"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+          },
+          "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+          "id": "5gqoUf9vKKv96b1c0GBKwu",
+          "name": "Dusky",
+          "type": "artist",
+          "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 209685,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205460"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2PuJiEG6QCfOCmrbjLepgr"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2PuJiEG6QCfOCmrbjLepgr",
+      "id": "2PuJiEG6QCfOCmrbjLepgr",
+      "is_local": false,
+      "name": "Northbound",
+      "popularity": 33,
+      "preview_url": "https://p.scdn.co/mp3-preview/6383e9659da368a858c9177371ff874b00e8cef4?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 4,
+      "type": "track",
+      "uri": "spotify:track:2PuJiEG6QCfOCmrbjLepgr"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2avRYQUWQpIkzJOEkf0MdY"
+            },
+            "href": "https://api.spotify.com/v1/artists/2avRYQUWQpIkzJOEkf0MdY",
+            "id": "2avRYQUWQpIkzJOEkf0MdY",
+            "name": "Kx5",
+            "type": "artist",
+            "uri": "spotify:artist:2avRYQUWQpIkzJOEkf0MdY"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+            },
+            "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+            "id": "2CIMQHirSU0MQqyYHq0eOx",
+            "name": "deadmau5",
+            "type": "artist",
+            "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6TQj5BFPooTa08A7pk8AQ1"
+            },
+            "href": "https://api.spotify.com/v1/artists/6TQj5BFPooTa08A7pk8AQ1",
+            "id": "6TQj5BFPooTa08A7pk8AQ1",
+            "name": "Kaskade",
+            "type": "artist",
+            "uri": "spotify:artist:6TQj5BFPooTa08A7pk8AQ1"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/5nTSB1dEcWtAtkWnHgOcMR"
+        },
+        "href": "https://api.spotify.com/v1/albums/5nTSB1dEcWtAtkWnHgOcMR",
+        "id": "5nTSB1dEcWtAtkWnHgOcMR",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2733257a0ad4aa2ccad6a24908b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e023257a0ad4aa2ccad6a24908b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048513257a0ad4aa2ccad6a24908b",
+            "width": 64
+          }
+        ],
+        "name": "Alive (feat. The Moth & The Flame)",
+        "release_date": "2022-10-11",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:5nTSB1dEcWtAtkWnHgOcMR"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2avRYQUWQpIkzJOEkf0MdY"
+          },
+          "href": "https://api.spotify.com/v1/artists/2avRYQUWQpIkzJOEkf0MdY",
+          "id": "2avRYQUWQpIkzJOEkf0MdY",
+          "name": "Kx5",
+          "type": "artist",
+          "uri": "spotify:artist:2avRYQUWQpIkzJOEkf0MdY"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+          },
+          "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+          "id": "2CIMQHirSU0MQqyYHq0eOx",
+          "name": "deadmau5",
+          "type": "artist",
+          "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6TQj5BFPooTa08A7pk8AQ1"
+          },
+          "href": "https://api.spotify.com/v1/artists/6TQj5BFPooTa08A7pk8AQ1",
+          "id": "6TQj5BFPooTa08A7pk8AQ1",
+          "name": "Kaskade",
+          "type": "artist",
+          "uri": "spotify:artist:6TQj5BFPooTa08A7pk8AQ1"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6Fk18HpdnXUsKWpN9mPb9R"
+          },
+          "href": "https://api.spotify.com/v1/artists/6Fk18HpdnXUsKWpN9mPb9R",
+          "id": "6Fk18HpdnXUsKWpN9mPb9R",
+          "name": "The Moth & The Flame",
+          "type": "artist",
+          "uri": "spotify:artist:6Fk18HpdnXUsKWpN9mPb9R"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 308709,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBTDG1302561"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1SETgPENHVzsWoD9g79LYI"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1SETgPENHVzsWoD9g79LYI",
+      "id": "1SETgPENHVzsWoD9g79LYI",
+      "is_local": false,
+      "name": "Alive (feat. The Moth & The Flame)",
+      "popularity": 64,
+      "preview_url": "https://p.scdn.co/mp3-preview/3cb22178dbea5cccf38c9b8b266ae73c517cb3ec?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1SETgPENHVzsWoD9g79LYI"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0ynzbXwyCzxicMKHBoOkSH"
+            },
+            "href": "https://api.spotify.com/v1/artists/0ynzbXwyCzxicMKHBoOkSH",
+            "id": "0ynzbXwyCzxicMKHBoOkSH",
+            "name": "EKKSTACY",
+            "type": "artist",
+            "uri": "spotify:artist:0ynzbXwyCzxicMKHBoOkSH"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6tdl27ojBwZ5ZexzZOP4mG"
+        },
+        "href": "https://api.spotify.com/v1/albums/6tdl27ojBwZ5ZexzZOP4mG",
+        "id": "6tdl27ojBwZ5ZexzZOP4mG",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27357f165027c8170e37e526b86",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0257f165027c8170e37e526b86",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485157f165027c8170e37e526b86",
+            "width": 64
+          }
+        ],
+        "name": "i walk this earth all by myself",
+        "release_date": "2021-03-05",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:6tdl27ojBwZ5ZexzZOP4mG"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0ynzbXwyCzxicMKHBoOkSH"
+          },
+          "href": "https://api.spotify.com/v1/artists/0ynzbXwyCzxicMKHBoOkSH",
+          "id": "0ynzbXwyCzxicMKHBoOkSH",
+          "name": "EKKSTACY",
+          "type": "artist",
+          "uri": "spotify:artist:0ynzbXwyCzxicMKHBoOkSH"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 145634,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "QZNMU2174737"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5a8QUc4ubHJqQm7vzs2YhA"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5a8QUc4ubHJqQm7vzs2YhA",
+      "id": "5a8QUc4ubHJqQm7vzs2YhA",
+      "is_local": false,
+      "name": "i walk this earth all by myself",
+      "popularity": 71,
+      "preview_url": "https://p.scdn.co/mp3-preview/34c27a848aa3a3e4387408d8e15ef0fc61f696df?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5a8QUc4ubHJqQm7vzs2YhA"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1BqIPGrEhdjdLFpUzce2dh"
+            },
+            "href": "https://api.spotify.com/v1/artists/1BqIPGrEhdjdLFpUzce2dh",
+            "id": "1BqIPGrEhdjdLFpUzce2dh",
+            "name": "Durante",
+            "type": "artist",
+            "uri": "spotify:artist:1BqIPGrEhdjdLFpUzce2dh"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/3drFZq7mJtUkGEq5duNBAM"
+        },
+        "href": "https://api.spotify.com/v1/albums/3drFZq7mJtUkGEq5duNBAM",
+        "id": "3drFZq7mJtUkGEq5duNBAM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273b4ef320f98f3a28f5262a79b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02b4ef320f98f3a28f5262a79b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851b4ef320f98f3a28f5262a79b",
+            "width": 64
+          }
+        ],
+        "name": "Unraveled",
+        "release_date": "2017-11-24",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:3drFZq7mJtUkGEq5duNBAM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1BqIPGrEhdjdLFpUzce2dh"
+          },
+          "href": "https://api.spotify.com/v1/artists/1BqIPGrEhdjdLFpUzce2dh",
+          "id": "1BqIPGrEhdjdLFpUzce2dh",
+          "name": "Durante",
+          "type": "artist",
+          "uri": "spotify:artist:1BqIPGrEhdjdLFpUzce2dh"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 334761,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USYBL1701677"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2DxlImGfZPKLLhqqEl1nbW"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2DxlImGfZPKLLhqqEl1nbW",
+      "id": "2DxlImGfZPKLLhqqEl1nbW",
+      "is_local": false,
+      "name": "Split Wick",
+      "popularity": 42,
+      "preview_url": "https://p.scdn.co/mp3-preview/ee9313f8c849a1163514f399f820731c9c49efde?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:2DxlImGfZPKLLhqqEl1nbW"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6nneI0xOh7SR2zvzHcvB5g"
+        },
+        "href": "https://api.spotify.com/v1/albums/6nneI0xOh7SR2zvzHcvB5g",
+        "id": "6nneI0xOh7SR2zvzHcvB5g",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f56d363d03630bf3ee50b705",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f56d363d03630bf3ee50b705",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f56d363d03630bf3ee50b705",
+            "width": 64
+          }
+        ],
+        "name": "Clara (the night is dark)",
+        "release_date": "2022-10-27",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:6nneI0xOh7SR2zvzHcvB5g"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 278400,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201036"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1PuxHPD8l3mm2CbxrMXy8N"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1PuxHPD8l3mm2CbxrMXy8N",
+      "id": "1PuxHPD8l3mm2CbxrMXy8N",
+      "is_local": false,
+      "name": "Clara (the night is dark)",
+      "popularity": 62,
+      "preview_url": "https://p.scdn.co/mp3-preview/e23dd172c6be452611ba3d7b803a0a3b768dc17a?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1PuxHPD8l3mm2CbxrMXy8N"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+            },
+            "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+            "id": "3OsRAKCvk37zwYcnzRf5XF",
+            "name": "Moby",
+            "type": "artist",
+            "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1xvxKcfieI9U1aEzOV8HCJ"
+        },
+        "href": "https://api.spotify.com/v1/albums/1xvxKcfieI9U1aEzOV8HCJ",
+        "id": "1xvxKcfieI9U1aEzOV8HCJ",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f2756789b4e46a2e1c01dbe5",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f2756789b4e46a2e1c01dbe5",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f2756789b4e46a2e1c01dbe5",
+            "width": 64
+          }
+        ],
+        "name": "Rescue Me",
+        "release_date": "2022-10-10",
+        "release_date_precision": "day",
+        "total_tracks": 6,
+        "type": "album",
+        "uri": "spotify:album:1xvxKcfieI9U1aEzOV8HCJ"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+          },
+          "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+          "id": "3OsRAKCvk37zwYcnzRf5XF",
+          "name": "Moby",
+          "type": "artist",
+          "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1vqfuBk5JF1LynFQZ19p3r"
+          },
+          "href": "https://api.spotify.com/v1/artists/1vqfuBk5JF1LynFQZ19p3r",
+          "id": "1vqfuBk5JF1LynFQZ19p3r",
+          "name": "Apollo Jane",
+          "type": "artist",
+          "uri": "spotify:artist:1vqfuBk5JF1LynFQZ19p3r"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 204055,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB3AD2210021"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/39QZxoXH9jfjmY8iwFyrNB"
+      },
+      "href": "https://api.spotify.com/v1/tracks/39QZxoXH9jfjmY8iwFyrNB",
+      "id": "39QZxoXH9jfjmY8iwFyrNB",
+      "is_local": false,
+      "name": "Rescue Me",
+      "popularity": 50,
+      "preview_url": "https://p.scdn.co/mp3-preview/2cb360bb14ba65af8f8e136a5dac1da6d3be9de6?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:39QZxoXH9jfjmY8iwFyrNB"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+            },
+            "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+            "id": "3OsRAKCvk37zwYcnzRf5XF",
+            "name": "Moby",
+            "type": "artist",
+            "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1xvxKcfieI9U1aEzOV8HCJ"
+        },
+        "href": "https://api.spotify.com/v1/albums/1xvxKcfieI9U1aEzOV8HCJ",
+        "id": "1xvxKcfieI9U1aEzOV8HCJ",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f2756789b4e46a2e1c01dbe5",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f2756789b4e46a2e1c01dbe5",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f2756789b4e46a2e1c01dbe5",
+            "width": 64
+          }
+        ],
+        "name": "Rescue Me",
+        "release_date": "2022-10-10",
+        "release_date_precision": "day",
+        "total_tracks": 6,
+        "type": "album",
+        "uri": "spotify:album:1xvxKcfieI9U1aEzOV8HCJ"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+          },
+          "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+          "id": "3OsRAKCvk37zwYcnzRf5XF",
+          "name": "Moby",
+          "type": "artist",
+          "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1vqfuBk5JF1LynFQZ19p3r"
+          },
+          "href": "https://api.spotify.com/v1/artists/1vqfuBk5JF1LynFQZ19p3r",
+          "id": "1vqfuBk5JF1LynFQZ19p3r",
+          "name": "Apollo Jane",
+          "type": "artist",
+          "uri": "spotify:artist:1vqfuBk5JF1LynFQZ19p3r"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 329379,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB3AD2210022"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/29JgLJAM6wAX20rnfm5nD0"
+      },
+      "href": "https://api.spotify.com/v1/tracks/29JgLJAM6wAX20rnfm5nD0",
+      "id": "29JgLJAM6wAX20rnfm5nD0",
+      "is_local": false,
+      "name": "Rescue Me - Quiet Version",
+      "popularity": 35,
+      "preview_url": "https://p.scdn.co/mp3-preview/ec6155f35a39aefdf06f15b9d6952ff1b5acf570?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:29JgLJAM6wAX20rnfm5nD0"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1lmP325N7mFdhDOl7tMfpL"
+            },
+            "href": "https://api.spotify.com/v1/artists/1lmP325N7mFdhDOl7tMfpL",
+            "id": "1lmP325N7mFdhDOl7tMfpL",
+            "name": "Forma",
+            "type": "artist",
+            "uri": "spotify:artist:1lmP325N7mFdhDOl7tMfpL"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/71rqI5HtraA3qXBwatyG6e"
+            },
+            "href": "https://api.spotify.com/v1/artists/71rqI5HtraA3qXBwatyG6e",
+            "id": "71rqI5HtraA3qXBwatyG6e",
+            "name": "Innellea",
+            "type": "artist",
+            "uri": "spotify:artist:71rqI5HtraA3qXBwatyG6e"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2ldvU2vukDp8TyH9qDie2G"
+        },
+        "href": "https://api.spotify.com/v1/albums/2ldvU2vukDp8TyH9qDie2G",
+        "id": "2ldvU2vukDp8TyH9qDie2G",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273d578f963ed02a36d4f124880",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02d578f963ed02a36d4f124880",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851d578f963ed02a36d4f124880",
+            "width": 64
+          }
+        ],
+        "name": "In Control (Innellea Remix)",
+        "release_date": "2022-09-14",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:2ldvU2vukDp8TyH9qDie2G"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1lmP325N7mFdhDOl7tMfpL"
+          },
+          "href": "https://api.spotify.com/v1/artists/1lmP325N7mFdhDOl7tMfpL",
+          "id": "1lmP325N7mFdhDOl7tMfpL",
+          "name": "Forma",
+          "type": "artist",
+          "uri": "spotify:artist:1lmP325N7mFdhDOl7tMfpL"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/71rqI5HtraA3qXBwatyG6e"
+          },
+          "href": "https://api.spotify.com/v1/artists/71rqI5HtraA3qXBwatyG6e",
+          "id": "71rqI5HtraA3qXBwatyG6e",
+          "name": "Innellea",
+          "type": "artist",
+          "uri": "spotify:artist:71rqI5HtraA3qXBwatyG6e"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 345135,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205120"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/35fdRgZrz5ujDGBaqhoPE8"
+      },
+      "href": "https://api.spotify.com/v1/tracks/35fdRgZrz5ujDGBaqhoPE8",
+      "id": "35fdRgZrz5ujDGBaqhoPE8",
+      "is_local": false,
+      "name": "In Control - Innellea Remix",
+      "popularity": 57,
+      "preview_url": "https://p.scdn.co/mp3-preview/0399074035c758534a206cf87d20599f6be1b95e?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:35fdRgZrz5ujDGBaqhoPE8"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0vTVU0KH0CVzijsoKGsTPl"
+            },
+            "href": "https://api.spotify.com/v1/artists/0vTVU0KH0CVzijsoKGsTPl",
+            "id": "0vTVU0KH0CVzijsoKGsTPl",
+            "name": "Barry Can't Swim",
+            "type": "artist",
+            "uri": "spotify:artist:0vTVU0KH0CVzijsoKGsTPl"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3mkzFWYCYAGqxo02F1trQL"
+            },
+            "href": "https://api.spotify.com/v1/artists/3mkzFWYCYAGqxo02F1trQL",
+            "id": "3mkzFWYCYAGqxo02F1trQL",
+            "name": "Taite Imogen",
+            "type": "artist",
+            "uri": "spotify:artist:3mkzFWYCYAGqxo02F1trQL"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0URZfqUQlB4JreGiq1KiK9"
+        },
+        "href": "https://api.spotify.com/v1/albums/0URZfqUQlB4JreGiq1KiK9",
+        "id": "0URZfqUQlB4JreGiq1KiK9",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273c3a29135b4ffc2cd146447b8",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02c3a29135b4ffc2cd146447b8",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851c3a29135b4ffc2cd146447b8",
+            "width": 64
+          }
+        ],
+        "name": "God Is The Space Between Us",
+        "release_date": "2022-03-30",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:0URZfqUQlB4JreGiq1KiK9"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0vTVU0KH0CVzijsoKGsTPl"
+          },
+          "href": "https://api.spotify.com/v1/artists/0vTVU0KH0CVzijsoKGsTPl",
+          "id": "0vTVU0KH0CVzijsoKGsTPl",
+          "name": "Barry Can't Swim",
+          "type": "artist",
+          "uri": "spotify:artist:0vTVU0KH0CVzijsoKGsTPl"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3mkzFWYCYAGqxo02F1trQL"
+          },
+          "href": "https://api.spotify.com/v1/artists/3mkzFWYCYAGqxo02F1trQL",
+          "id": "3mkzFWYCYAGqxo02F1trQL",
+          "name": "Taite Imogen",
+          "type": "artist",
+          "uri": "spotify:artist:3mkzFWYCYAGqxo02F1trQL"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 187988,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBCFB2200129"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5I73WkfhuOvavHVYk3TGrm"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5I73WkfhuOvavHVYk3TGrm",
+      "id": "5I73WkfhuOvavHVYk3TGrm",
+      "is_local": false,
+      "name": "God Is The Space Between Us",
+      "popularity": 61,
+      "preview_url": "https://p.scdn.co/mp3-preview/8a9724078bbc3de0ccd76c2bc018ec3ca7a7c58d?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5I73WkfhuOvavHVYk3TGrm"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0QaSiI5TLA4N7mcsdxShDO"
+            },
+            "href": "https://api.spotify.com/v1/artists/0QaSiI5TLA4N7mcsdxShDO",
+            "id": "0QaSiI5TLA4N7mcsdxShDO",
+            "name": "Sub Focus",
+            "type": "artist",
+            "uri": "spotify:artist:0QaSiI5TLA4N7mcsdxShDO"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+            },
+            "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+            "id": "1QMgre3BHX161ZHtWMUu6S",
+            "name": "Dimension",
+            "type": "artist",
+            "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0Gt9NV2s7pSvP7g2F1nXGc"
+        },
+        "href": "https://api.spotify.com/v1/albums/0Gt9NV2s7pSvP7g2F1nXGc",
+        "id": "0Gt9NV2s7pSvP7g2F1nXGc",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273b496a5def7e67052028cde20",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02b496a5def7e67052028cde20",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851b496a5def7e67052028cde20",
+            "width": 64
+          }
+        ],
+        "name": "Ready To Fly",
+        "release_date": "2022-10-07",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:0Gt9NV2s7pSvP7g2F1nXGc"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0QaSiI5TLA4N7mcsdxShDO"
+          },
+          "href": "https://api.spotify.com/v1/artists/0QaSiI5TLA4N7mcsdxShDO",
+          "id": "0QaSiI5TLA4N7mcsdxShDO",
+          "name": "Sub Focus",
+          "type": "artist",
+          "uri": "spotify:artist:0QaSiI5TLA4N7mcsdxShDO"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+          },
+          "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+          "id": "1QMgre3BHX161ZHtWMUu6S",
+          "name": "Dimension",
+          "type": "artist",
+          "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 204500,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBUM72206309"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/0a2cA9H6KuOsoHLCnjl6YL"
+      },
+      "href": "https://api.spotify.com/v1/tracks/0a2cA9H6KuOsoHLCnjl6YL",
+      "id": "0a2cA9H6KuOsoHLCnjl6YL",
+      "is_local": false,
+      "name": "Ready To Fly",
+      "popularity": 66,
+      "preview_url": "https://p.scdn.co/mp3-preview/1613d8fed25c29bdcfa2681f74a2a29b2de9e43c?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:0a2cA9H6KuOsoHLCnjl6YL"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0pWwt5vGNzezEhfAcc420Y"
+            },
+            "href": "https://api.spotify.com/v1/artists/0pWwt5vGNzezEhfAcc420Y",
+            "id": "0pWwt5vGNzezEhfAcc420Y",
+            "name": "Mr.Kitty",
+            "type": "artist",
+            "uri": "spotify:artist:0pWwt5vGNzezEhfAcc420Y"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0yeP5olfo8IIu6UBGfUWHo"
+        },
+        "href": "https://api.spotify.com/v1/albums/0yeP5olfo8IIu6UBGfUWHo",
+        "id": "0yeP5olfo8IIu6UBGfUWHo",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2732c8acf6e66607fff1fd23841",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e022c8acf6e66607fff1fd23841",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048512c8acf6e66607fff1fd23841",
+            "width": 64
+          }
+        ],
+        "name": "Time",
+        "release_date": "2014-08-08",
+        "release_date_precision": "day",
+        "total_tracks": 15,
+        "type": "album",
+        "uri": "spotify:album:0yeP5olfo8IIu6UBGfUWHo"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0pWwt5vGNzezEhfAcc420Y"
+          },
+          "href": "https://api.spotify.com/v1/artists/0pWwt5vGNzezEhfAcc420Y",
+          "id": "0pWwt5vGNzezEhfAcc420Y",
+          "name": "Mr.Kitty",
+          "type": "artist",
+          "uri": "spotify:artist:0pWwt5vGNzezEhfAcc420Y"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 257147,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKPL1412568"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5FkJHVudUByVjanCqFXRql"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5FkJHVudUByVjanCqFXRql",
+      "id": "5FkJHVudUByVjanCqFXRql",
+      "is_local": false,
+      "name": "After Dark",
+      "popularity": 73,
+      "preview_url": "https://p.scdn.co/mp3-preview/59a86a705559f616bddbf476c7c60257872d68f2?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 9,
+      "type": "track",
+      "uri": "spotify:track:5FkJHVudUByVjanCqFXRql"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
+            },
+            "href": "https://api.spotify.com/v1/artists/3AA28KZvwAUcZuOKwyblJQ",
+            "id": "3AA28KZvwAUcZuOKwyblJQ",
+            "name": "Gorillaz",
+            "type": "artist",
+            "uri": "spotify:artist:3AA28KZvwAUcZuOKwyblJQ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+            },
+            "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+            "id": "5INjqkS1o8h1imAzPqGZBb",
+            "name": "Tame Impala",
+            "type": "artist",
+            "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6GI3CJjT2bOnMfprCpjT1d"
+            },
+            "href": "https://api.spotify.com/v1/artists/6GI3CJjT2bOnMfprCpjT1d",
+            "id": "6GI3CJjT2bOnMfprCpjT1d",
+            "name": "Bootie Brown",
+            "type": "artist",
+            "uri": "spotify:artist:6GI3CJjT2bOnMfprCpjT1d"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4V9YFKLqZ5h8nQFTvDQscC"
+        },
+        "href": "https://api.spotify.com/v1/albums/4V9YFKLqZ5h8nQFTvDQscC",
+        "id": "4V9YFKLqZ5h8nQFTvDQscC",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273fda889bb57058a4a1b88edcd",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02fda889bb57058a4a1b88edcd",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851fda889bb57058a4a1b88edcd",
+            "width": 64
+          }
+        ],
+        "name": "New Gold (feat. Tame Impala and Bootie Brown)",
+        "release_date": "2022-08-31",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:4V9YFKLqZ5h8nQFTvDQscC"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
+          },
+          "href": "https://api.spotify.com/v1/artists/3AA28KZvwAUcZuOKwyblJQ",
+          "id": "3AA28KZvwAUcZuOKwyblJQ",
+          "name": "Gorillaz",
+          "type": "artist",
+          "uri": "spotify:artist:3AA28KZvwAUcZuOKwyblJQ"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+          },
+          "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+          "id": "5INjqkS1o8h1imAzPqGZBb",
+          "name": "Tame Impala",
+          "type": "artist",
+          "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6GI3CJjT2bOnMfprCpjT1d"
+          },
+          "href": "https://api.spotify.com/v1/artists/6GI3CJjT2bOnMfprCpjT1d",
+          "id": "6GI3CJjT2bOnMfprCpjT1d",
+          "name": "Bootie Brown",
+          "type": "artist",
+          "uri": "spotify:artist:6GI3CJjT2bOnMfprCpjT1d"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 215149,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBAYE2200462"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/64dLd6rVqDLtkXFYrEUHIU"
+      },
+      "href": "https://api.spotify.com/v1/tracks/64dLd6rVqDLtkXFYrEUHIU",
+      "id": "64dLd6rVqDLtkXFYrEUHIU",
+      "is_local": false,
+      "name": "New Gold (feat. Tame Impala and Bootie Brown)",
+      "popularity": 80,
+      "preview_url": "https://p.scdn.co/mp3-preview/2d4f3af6a427a293cd0a0542242cfe60cd1ff4d3?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:64dLd6rVqDLtkXFYrEUHIU"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/49GY4uPAwdlk5lSGtfKWYl"
+            },
+            "href": "https://api.spotify.com/v1/artists/49GY4uPAwdlk5lSGtfKWYl",
+            "id": "49GY4uPAwdlk5lSGtfKWYl",
+            "name": "MJ Cole",
+            "type": "artist",
+            "uri": "spotify:artist:49GY4uPAwdlk5lSGtfKWYl"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0yT3AhIS383pWxB8W9VV1r"
+        },
+        "href": "https://api.spotify.com/v1/albums/0yT3AhIS383pWxB8W9VV1r",
+        "id": "0yT3AhIS383pWxB8W9VV1r",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27316dea558effd9e469fb989cb",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0216dea558effd9e469fb989cb",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485116dea558effd9e469fb989cb",
+            "width": 64
+          }
+        ],
+        "name": "Waking Up",
+        "release_date": "2019-02-27",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:0yT3AhIS383pWxB8W9VV1r"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/49GY4uPAwdlk5lSGtfKWYl"
+          },
+          "href": "https://api.spotify.com/v1/artists/49GY4uPAwdlk5lSGtfKWYl",
+          "id": "49GY4uPAwdlk5lSGtfKWYl",
+          "name": "MJ Cole",
+          "type": "artist",
+          "uri": "spotify:artist:49GY4uPAwdlk5lSGtfKWYl"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 259204,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "US23A1501191"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7z6YhYLnLkLOw2qBhH5CTh"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7z6YhYLnLkLOw2qBhH5CTh",
+      "id": "7z6YhYLnLkLOw2qBhH5CTh",
+      "is_local": false,
+      "name": "Serotonin",
+      "popularity": 41,
+      "preview_url": "https://p.scdn.co/mp3-preview/cfd9b11398f926904997ac56a81dd7de19e6d9a1?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 3,
+      "type": "track",
+      "uri": "spotify:track:7z6YhYLnLkLOw2qBhH5CTh"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+            },
+            "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+            "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+            "name": "Netsky",
+            "type": "artist",
+            "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6Bi0LU2EWGrSRybRuYsScL"
+        },
+        "href": "https://api.spotify.com/v1/albums/6Bi0LU2EWGrSRybRuYsScL",
+        "id": "6Bi0LU2EWGrSRybRuYsScL",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27363f80eddab655fd5efb21d92",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0263f80eddab655fd5efb21d92",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485163f80eddab655fd5efb21d92",
+            "width": 64
+          }
+        ],
+        "name": "I Refuse / Midnight Express",
+        "release_date": "2010",
+        "release_date_precision": "year",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:6Bi0LU2EWGrSRybRuYsScL"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+          },
+          "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+          "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+          "name": "Netsky",
+          "type": "artist",
+          "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 355862,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBQZQ0901130"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1OBi4IRkuVOCegnDHG3xhj"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1OBi4IRkuVOCegnDHG3xhj",
+      "id": "1OBi4IRkuVOCegnDHG3xhj",
+      "is_local": false,
+      "name": "I Refuse",
+      "popularity": 41,
+      "preview_url": "https://p.scdn.co/mp3-preview/a5e7888f5e258224484910c23aa71227dc8c2945?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1OBi4IRkuVOCegnDHG3xhj"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6ZHeg2Op5ZkNppXbNLSglj"
+            },
+            "href": "https://api.spotify.com/v1/artists/6ZHeg2Op5ZkNppXbNLSglj",
+            "id": "6ZHeg2Op5ZkNppXbNLSglj",
+            "name": "Willaris. K",
+            "type": "artist",
+            "uri": "spotify:artist:6ZHeg2Op5ZkNppXbNLSglj"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/3pPn8xjYMTi303ZEs7tujA"
+        },
+        "href": "https://api.spotify.com/v1/albums/3pPn8xjYMTi303ZEs7tujA",
+        "id": "3pPn8xjYMTi303ZEs7tujA",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a2b602200e9758e7f6ae20bc",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a2b602200e9758e7f6ae20bc",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a2b602200e9758e7f6ae20bc",
+            "width": 64
+          }
+        ],
+        "name": "Double Demerits / Harsh",
+        "release_date": "2022-09-27",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:3pPn8xjYMTi303ZEs7tujA"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6ZHeg2Op5ZkNppXbNLSglj"
+          },
+          "href": "https://api.spotify.com/v1/artists/6ZHeg2Op5ZkNppXbNLSglj",
+          "id": "6ZHeg2Op5ZkNppXbNLSglj",
+          "name": "Willaris. K",
+          "type": "artist",
+          "uri": "spotify:artist:6ZHeg2Op5ZkNppXbNLSglj"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 298643,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USUG12206728"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7xP8b4AiHoT8gLYsZrdTem"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7xP8b4AiHoT8gLYsZrdTem",
+      "id": "7xP8b4AiHoT8gLYsZrdTem",
+      "is_local": false,
+      "name": "Double Demerits",
+      "popularity": 18,
+      "preview_url": "https://p.scdn.co/mp3-preview/584d26cfc723c8c3c0092ec616021ea250ef4469?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:7xP8b4AiHoT8gLYsZrdTem"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6xq7g0E52yq4y8Op9X82Uo"
+            },
+            "href": "https://api.spotify.com/v1/artists/6xq7g0E52yq4y8Op9X82Uo",
+            "id": "6xq7g0E52yq4y8Op9X82Uo",
+            "name": "TIBASKO",
+            "type": "artist",
+            "uri": "spotify:artist:6xq7g0E52yq4y8Op9X82Uo"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4mxQ6vTBvss4je3abdHWp8"
+        },
+        "href": "https://api.spotify.com/v1/albums/4mxQ6vTBvss4je3abdHWp8",
+        "id": "4mxQ6vTBvss4je3abdHWp8",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273bf597affee18cf1ceeecadc2",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02bf597affee18cf1ceeecadc2",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851bf597affee18cf1ceeecadc2",
+            "width": 64
+          }
+        ],
+        "name": "Still Rushing / System Error",
+        "release_date": "2022-07-29",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:4mxQ6vTBvss4je3abdHWp8"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6xq7g0E52yq4y8Op9X82Uo"
+          },
+          "href": "https://api.spotify.com/v1/artists/6xq7g0E52yq4y8Op9X82Uo",
+          "id": "6xq7g0E52yq4y8Op9X82Uo",
+          "name": "TIBASKO",
+          "type": "artist",
+          "uri": "spotify:artist:6xq7g0E52yq4y8Op9X82Uo"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 226173,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKQU2258572"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/18SaC9Z58nrfjkWbSZUjG3"
+      },
+      "href": "https://api.spotify.com/v1/tracks/18SaC9Z58nrfjkWbSZUjG3",
+      "id": "18SaC9Z58nrfjkWbSZUjG3",
+      "is_local": false,
+      "name": "Still Rushing",
+      "popularity": 34,
+      "preview_url": "https://p.scdn.co/mp3-preview/8c2040f0da2ad3080a31eb33362807f0bc8a686e?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:18SaC9Z58nrfjkWbSZUjG3"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+            },
+            "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+            "id": "2CIMQHirSU0MQqyYHq0eOx",
+            "name": "deadmau5",
+            "type": "artist",
+            "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+            },
+            "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+            "id": "1QMgre3BHX161ZHtWMUu6S",
+            "name": "Dimension",
+            "type": "artist",
+            "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1C3Agf6jqcHNRSeSneAoMg"
+        },
+        "href": "https://api.spotify.com/v1/albums/1C3Agf6jqcHNRSeSneAoMg",
+        "id": "1C3Agf6jqcHNRSeSneAoMg",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2731e60c7f2cbd8d3026c50a7c3",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e021e60c7f2cbd8d3026c50a7c3",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048511e60c7f2cbd8d3026c50a7c3",
+            "width": 64
+          }
+        ],
+        "name": "Strobe (Dimension Remix)",
+        "release_date": "2016-09-22",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:1C3Agf6jqcHNRSeSneAoMg"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+          },
+          "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+          "id": "2CIMQHirSU0MQqyYHq0eOx",
+          "name": "deadmau5",
+          "type": "artist",
+          "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+          },
+          "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+          "id": "1QMgre3BHX161ZHtWMUu6S",
+          "name": "Dimension",
+          "type": "artist",
+          "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 508965,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBTDG1301165"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/34kjfTbXaqCHIaKatdNYVd"
+      },
+      "href": "https://api.spotify.com/v1/tracks/34kjfTbXaqCHIaKatdNYVd",
+      "id": "34kjfTbXaqCHIaKatdNYVd",
+      "is_local": false,
+      "name": "Strobe - Dimension Remix",
+      "popularity": 24,
+      "preview_url": "https://p.scdn.co/mp3-preview/8dd93dfa721e52531e91e9002501ec08dc4e0405?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:34kjfTbXaqCHIaKatdNYVd"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0bGDTQ78MVgI5Snqo9KJZw"
+            },
+            "href": "https://api.spotify.com/v1/artists/0bGDTQ78MVgI5Snqo9KJZw",
+            "id": "0bGDTQ78MVgI5Snqo9KJZw",
+            "name": "Qrion",
+            "type": "artist",
+            "uri": "spotify:artist:0bGDTQ78MVgI5Snqo9KJZw"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0xyI5ztV0OXUVgZHxLUkzH"
+        },
+        "href": "https://api.spotify.com/v1/albums/0xyI5ztV0OXUVgZHxLUkzH",
+        "id": "0xyI5ztV0OXUVgZHxLUkzH",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273526c200e6064faa615b771ed",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02526c200e6064faa615b771ed",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851526c200e6064faa615b771ed",
+            "width": 64
+          }
+        ],
+        "name": "Proud",
+        "release_date": "2021-10-12",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:0xyI5ztV0OXUVgZHxLUkzH"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0bGDTQ78MVgI5Snqo9KJZw"
+          },
+          "href": "https://api.spotify.com/v1/artists/0bGDTQ78MVgI5Snqo9KJZw",
+          "id": "0bGDTQ78MVgI5Snqo9KJZw",
+          "name": "Qrion",
+          "type": "artist",
+          "uri": "spotify:artist:0bGDTQ78MVgI5Snqo9KJZw"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 236101,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2104531"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/57fgc1wsUpAj0BfTHncOaT"
+      },
+      "href": "https://api.spotify.com/v1/tracks/57fgc1wsUpAj0BfTHncOaT",
+      "id": "57fgc1wsUpAj0BfTHncOaT",
+      "is_local": false,
+      "name": "Proud",
+      "popularity": 33,
+      "preview_url": "https://p.scdn.co/mp3-preview/949e7ce92109713256c0be00633b712fde3bca2e?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:57fgc1wsUpAj0BfTHncOaT"
+    },
+    {
+      "album": {
+        "album_type": "COMPILATION",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/10gzBoINW3cLJfZUka8Zoe"
+            },
+            "href": "https://api.spotify.com/v1/artists/10gzBoINW3cLJfZUka8Zoe",
+            "id": "10gzBoINW3cLJfZUka8Zoe",
+            "name": "Above & Beyond",
+            "type": "artist",
+            "uri": "spotify:artist:10gzBoINW3cLJfZUka8Zoe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/3SppKnyNf5sdqLxCMwsTzX"
+        },
+        "href": "https://api.spotify.com/v1/albums/3SppKnyNf5sdqLxCMwsTzX",
+        "id": "3SppKnyNf5sdqLxCMwsTzX",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273e7edcaad955451771f08ff3b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02e7edcaad955451771f08ff3b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851e7edcaad955451771f08ff3b",
+            "width": 64
+          }
+        ],
+        "name": "Anjunabeats Volume 14",
+        "release_date": "2019-05-31",
+        "release_date_precision": "day",
+        "total_tracks": 39,
+        "type": "album",
+        "uri": "spotify:album:3SppKnyNf5sdqLxCMwsTzX"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6TwTAUcCILwoSPY2N3etuY"
+          },
+          "href": "https://api.spotify.com/v1/artists/6TwTAUcCILwoSPY2N3etuY",
+          "id": "6TwTAUcCILwoSPY2N3etuY",
+          "name": "Reflekt",
+          "type": "artist",
+          "uri": "spotify:artist:6TwTAUcCILwoSPY2N3etuY"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4mYOtUmFApJtEbaeGt0RCk"
+          },
+          "href": "https://api.spotify.com/v1/artists/4mYOtUmFApJtEbaeGt0RCk",
+          "id": "4mYOtUmFApJtEbaeGt0RCk",
+          "name": "delline bass",
+          "type": "artist",
+          "uri": "spotify:artist:4mYOtUmFApJtEbaeGt0RCk"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5EmEZjq8eHEC6qFnT63Lza"
+          },
+          "href": "https://api.spotify.com/v1/artists/5EmEZjq8eHEC6qFnT63Lza",
+          "id": "5EmEZjq8eHEC6qFnT63Lza",
+          "name": "Tinlicker",
+          "type": "artist",
+          "uri": "spotify:artist:5EmEZjq8eHEC6qFnT63Lza"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 308053,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA1900917"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5bHbUMtuZIpHtTPdoJmcaN"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5bHbUMtuZIpHtTPdoJmcaN",
+      "id": "5bHbUMtuZIpHtTPdoJmcaN",
+      "is_local": false,
+      "name": "Need To Feel Loved - Tinlicker Remix",
+      "popularity": 51,
+      "preview_url": "https://p.scdn.co/mp3-preview/7d62f1501998c3109c05309e3e846e2c8290bfe8?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 8,
+      "type": "track",
+      "uri": "spotify:track:5bHbUMtuZIpHtTPdoJmcaN"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0SFtIrRytNI4kcf93Tbhdf"
+        },
+        "href": "https://api.spotify.com/v1/albums/0SFtIrRytNI4kcf93Tbhdf",
+        "id": "0SFtIrRytNI4kcf93Tbhdf",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a871bc3a84418ad1240a5d4e",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a871bc3a84418ad1240a5d4e",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a871bc3a84418ad1240a5d4e",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 2 (February 2 - October 15 2021)",
+        "release_date": "2021-11-19",
+        "release_date_precision": "day",
+        "total_tracks": 16,
+        "type": "album",
+        "uri": "spotify:album:0SFtIrRytNI4kcf93Tbhdf"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 121708,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2101341"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/03LSUjL0Rqh2Lpj1rKgsmG"
+      },
+      "href": "https://api.spotify.com/v1/tracks/03LSUjL0Rqh2Lpj1rKgsmG",
+      "id": "03LSUjL0Rqh2Lpj1rKgsmG",
+      "is_local": false,
+      "name": "Carlos (interlude)",
+      "popularity": 43,
+      "preview_url": "https://p.scdn.co/mp3-preview/d0d3636d957baad12fe2e58f759607d2d922236b?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 8,
+      "type": "track",
+      "uri": "spotify:track:03LSUjL0Rqh2Lpj1rKgsmG"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4cxzGdmQtUZJL1WYOdFQ5F"
+            },
+            "href": "https://api.spotify.com/v1/artists/4cxzGdmQtUZJL1WYOdFQ5F",
+            "id": "4cxzGdmQtUZJL1WYOdFQ5F",
+            "name": "Kove",
+            "type": "artist",
+            "uri": "spotify:artist:4cxzGdmQtUZJL1WYOdFQ5F"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6MfYv3Zkj5zwMNbUfbAifz"
+            },
+            "href": "https://api.spotify.com/v1/artists/6MfYv3Zkj5zwMNbUfbAifz",
+            "id": "6MfYv3Zkj5zwMNbUfbAifz",
+            "name": "Ben Duffy",
+            "type": "artist",
+            "uri": "spotify:artist:6MfYv3Zkj5zwMNbUfbAifz"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2nlfwe48o2mE0Jam3uN88C"
+        },
+        "href": "https://api.spotify.com/v1/albums/2nlfwe48o2mE0Jam3uN88C",
+        "id": "2nlfwe48o2mE0Jam3uN88C",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27343e421b48df3b4a09ce3c722",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0243e421b48df3b4a09ce3c722",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485143e421b48df3b4a09ce3c722",
+            "width": 64
+          }
+        ],
+        "name": "Echoes",
+        "release_date": "2019-03-29",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:2nlfwe48o2mE0Jam3uN88C"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4cxzGdmQtUZJL1WYOdFQ5F"
+          },
+          "href": "https://api.spotify.com/v1/artists/4cxzGdmQtUZJL1WYOdFQ5F",
+          "id": "4cxzGdmQtUZJL1WYOdFQ5F",
+          "name": "Kove",
+          "type": "artist",
+          "uri": "spotify:artist:4cxzGdmQtUZJL1WYOdFQ5F"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6MfYv3Zkj5zwMNbUfbAifz"
+          },
+          "href": "https://api.spotify.com/v1/artists/6MfYv3Zkj5zwMNbUfbAifz",
+          "id": "6MfYv3Zkj5zwMNbUfbAifz",
+          "name": "Ben Duffy",
+          "type": "artist",
+          "uri": "spotify:artist:6MfYv3Zkj5zwMNbUfbAifz"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 194482,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB2LD1900072"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2vS2LgcY2FclC21sJ4ukJm"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2vS2LgcY2FclC21sJ4ukJm",
+      "id": "2vS2LgcY2FclC21sJ4ukJm",
+      "is_local": false,
+      "name": "Echoes",
+      "popularity": 53,
+      "preview_url": "https://p.scdn.co/mp3-preview/292f4108ec0cb7c7bc35a95e7e9f66247bf81e06?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:2vS2LgcY2FclC21sJ4ukJm"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/532SqCIYmJyXEdEiCJLgYG"
+            },
+            "href": "https://api.spotify.com/v1/artists/532SqCIYmJyXEdEiCJLgYG",
+            "id": "532SqCIYmJyXEdEiCJLgYG",
+            "name": "Cristoph",
+            "type": "artist",
+            "uri": "spotify:artist:532SqCIYmJyXEdEiCJLgYG"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+            "id": "3IG3Ub4ra8AuSxCFDVkVco",
+            "name": "Franky Wah",
+            "type": "artist",
+            "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/75urDDpUkt0jMdQgVx3XFV"
+            },
+            "href": "https://api.spotify.com/v1/artists/75urDDpUkt0jMdQgVx3XFV",
+            "id": "75urDDpUkt0jMdQgVx3XFV",
+            "name": "Artche",
+            "type": "artist",
+            "uri": "spotify:artist:75urDDpUkt0jMdQgVx3XFV"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0V9gdn8ZnhvkpRAvdnkT7I"
+        },
+        "href": "https://api.spotify.com/v1/albums/0V9gdn8ZnhvkpRAvdnkT7I",
+        "id": "0V9gdn8ZnhvkpRAvdnkT7I",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273c549572dee0d38630951ee83",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02c549572dee0d38630951ee83",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851c549572dee0d38630951ee83",
+            "width": 64
+          }
+        ],
+        "name": "The World You See",
+        "release_date": "2021-02-26",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:0V9gdn8ZnhvkpRAvdnkT7I"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/532SqCIYmJyXEdEiCJLgYG"
+          },
+          "href": "https://api.spotify.com/v1/artists/532SqCIYmJyXEdEiCJLgYG",
+          "id": "532SqCIYmJyXEdEiCJLgYG",
+          "name": "Cristoph",
+          "type": "artist",
+          "uri": "spotify:artist:532SqCIYmJyXEdEiCJLgYG"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+          "id": "3IG3Ub4ra8AuSxCFDVkVco",
+          "name": "Franky Wah",
+          "type": "artist",
+          "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/75urDDpUkt0jMdQgVx3XFV"
+          },
+          "href": "https://api.spotify.com/v1/artists/75urDDpUkt0jMdQgVx3XFV",
+          "id": "75urDDpUkt0jMdQgVx3XFV",
+          "name": "Artche",
+          "type": "artist",
+          "uri": "spotify:artist:75urDDpUkt0jMdQgVx3XFV"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 217515,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB6CM2100173"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/4TQgbkv9CF1Qy4GIfpZeSO"
+      },
+      "href": "https://api.spotify.com/v1/tracks/4TQgbkv9CF1Qy4GIfpZeSO",
+      "id": "4TQgbkv9CF1Qy4GIfpZeSO",
+      "is_local": false,
+      "name": "The World You See",
+      "popularity": 50,
+      "preview_url": "https://p.scdn.co/mp3-preview/5ab4a2d1d5e74f4932d757e1929df57313f489bd?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:4TQgbkv9CF1Qy4GIfpZeSO"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6u4jLGLPuarS3i2XWHVxoS"
+            },
+            "href": "https://api.spotify.com/v1/artists/6u4jLGLPuarS3i2XWHVxoS",
+            "id": "6u4jLGLPuarS3i2XWHVxoS",
+            "name": "Sasha",
+            "type": "artist",
+            "uri": "spotify:artist:6u4jLGLPuarS3i2XWHVxoS"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+            "id": "3IG3Ub4ra8AuSxCFDVkVco",
+            "name": "Franky Wah",
+            "type": "artist",
+            "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/7jGjzC6P9754JS5UVKWifW"
+        },
+        "href": "https://api.spotify.com/v1/albums/7jGjzC6P9754JS5UVKWifW",
+        "id": "7jGjzC6P9754JS5UVKWifW",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2739c1fbc8be7e570f16309d28f",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e029c1fbc8be7e570f16309d28f",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048519c1fbc8be7e570f16309d28f",
+            "width": 64
+          }
+        ],
+        "name": "Haunted",
+        "release_date": "2020-12-18",
+        "release_date_precision": "day",
+        "total_tracks": 5,
+        "type": "album",
+        "uri": "spotify:album:7jGjzC6P9754JS5UVKWifW"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6u4jLGLPuarS3i2XWHVxoS"
+          },
+          "href": "https://api.spotify.com/v1/artists/6u4jLGLPuarS3i2XWHVxoS",
+          "id": "6u4jLGLPuarS3i2XWHVxoS",
+          "name": "Sasha",
+          "type": "artist",
+          "uri": "spotify:artist:6u4jLGLPuarS3i2XWHVxoS"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+          "id": "3IG3Ub4ra8AuSxCFDVkVco",
+          "name": "Franky Wah",
+          "type": "artist",
+          "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 256821,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "FRIDO2012419"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/6cm0CsFVU8QTLTVegPgHDm"
+      },
+      "href": "https://api.spotify.com/v1/tracks/6cm0CsFVU8QTLTVegPgHDm",
+      "id": "6cm0CsFVU8QTLTVegPgHDm",
+      "is_local": false,
+      "name": "Haunted",
+      "popularity": 35,
+      "preview_url": "https://p.scdn.co/mp3-preview/060e96323fcb0ba6d268e565d81aabb88f35e9f8?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:6cm0CsFVU8QTLTVegPgHDm"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+            },
+            "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+            "id": "0g3NiCRhEv7M4SEDMrpItN",
+            "name": "Totally Enormous Extinct Dinosaurs",
+            "type": "artist",
+            "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2VNsib3BSnjcR4Me2bW4iJ"
+        },
+        "href": "https://api.spotify.com/v1/albums/2VNsib3BSnjcR4Me2bW4iJ",
+        "id": "2VNsib3BSnjcR4Me2bW4iJ",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27394b507dbd18300a1cd94b7ff",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0294b507dbd18300a1cd94b7ff",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485194b507dbd18300a1cd94b7ff",
+            "width": 64
+          }
+        ],
+        "name": "Energy Fantasy (Remixes)",
+        "release_date": "2019-03-08",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:2VNsib3BSnjcR4Me2bW4iJ"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+          },
+          "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+          "id": "0g3NiCRhEv7M4SEDMrpItN",
+          "name": "Totally Enormous Extinct Dinosaurs",
+          "type": "artist",
+          "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2tEyBfwGBfQgLXeAJW0MgC"
+          },
+          "href": "https://api.spotify.com/v1/artists/2tEyBfwGBfQgLXeAJW0MgC",
+          "id": "2tEyBfwGBfQgLXeAJW0MgC",
+          "name": "Baltra",
+          "type": "artist",
+          "uri": "spotify:artist:2tEyBfwGBfQgLXeAJW0MgC"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 356080,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKPL1938581"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1rlmQKaW9Hp50cilO0zVZv"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1rlmQKaW9Hp50cilO0zVZv",
+      "id": "1rlmQKaW9Hp50cilO0zVZv",
+      "is_local": false,
+      "name": "Energy Fantasy - Baltra \"Vocal\" Remix",
+      "popularity": 11,
+      "preview_url": "https://p.scdn.co/mp3-preview/45fc159ee2b7a5486948457dfada0e20ead9e4ef?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1rlmQKaW9Hp50cilO0zVZv"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+            "id": "3IG3Ub4ra8AuSxCFDVkVco",
+            "name": "Franky Wah",
+            "type": "artist",
+            "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2NkaRLi1emHFYLRT2JqxbL"
+        },
+        "href": "https://api.spotify.com/v1/albums/2NkaRLi1emHFYLRT2JqxbL",
+        "id": "2NkaRLi1emHFYLRT2JqxbL",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273e81a614dbcec768ce0bfaa2c",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02e81a614dbcec768ce0bfaa2c",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851e81a614dbcec768ce0bfaa2c",
+            "width": 64
+          }
+        ],
+        "name": "The Revival, Vol. 1",
+        "release_date": "2020-05-29",
+        "release_date_precision": "day",
+        "total_tracks": 14,
+        "type": "album",
+        "uri": "spotify:album:2NkaRLi1emHFYLRT2JqxbL"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+          "id": "3IG3Ub4ra8AuSxCFDVkVco",
+          "name": "Franky Wah",
+          "type": "artist",
+          "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 325039,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBCEN2000021"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/23hbF7NYTvwYk4TICcu3ZR"
+      },
+      "href": "https://api.spotify.com/v1/tracks/23hbF7NYTvwYk4TICcu3ZR",
+      "id": "23hbF7NYTvwYk4TICcu3ZR",
+      "is_local": false,
+      "name": "Cry No More",
+      "popularity": 29,
+      "preview_url": "https://p.scdn.co/mp3-preview/2ae3119a628647df30dd9dc2dc22c4f68f49b64a?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 12,
+      "type": "track",
+      "uri": "spotify:track:23hbF7NYTvwYk4TICcu3ZR"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4lCsf6uYTVnWSKm99eKkdY"
+            },
+            "href": "https://api.spotify.com/v1/artists/4lCsf6uYTVnWSKm99eKkdY",
+            "id": "4lCsf6uYTVnWSKm99eKkdY",
+            "name": "Seekae",
+            "type": "artist",
+            "uri": "spotify:artist:4lCsf6uYTVnWSKm99eKkdY"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6ViDQATM3uoaXqjBS2h7pO"
+        },
+        "href": "https://api.spotify.com/v1/albums/6ViDQATM3uoaXqjBS2h7pO",
+        "id": "6ViDQATM3uoaXqjBS2h7pO",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a0084d69f43f8dc944e930b7",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a0084d69f43f8dc944e930b7",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a0084d69f43f8dc944e930b7",
+            "width": 64
+          }
+        ],
+        "name": "Test & Recognise (Remixes)",
+        "release_date": "2014-08-14",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:6ViDQATM3uoaXqjBS2h7pO"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4lCsf6uYTVnWSKm99eKkdY"
+          },
+          "href": "https://api.spotify.com/v1/artists/4lCsf6uYTVnWSKm99eKkdY",
+          "id": "4lCsf6uYTVnWSKm99eKkdY",
+          "name": "Seekae",
+          "type": "artist",
+          "uri": "spotify:artist:4lCsf6uYTVnWSKm99eKkdY"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6nxWCVXbOlEVRexSbLsTer"
+          },
+          "href": "https://api.spotify.com/v1/artists/6nxWCVXbOlEVRexSbLsTer",
+          "id": "6nxWCVXbOlEVRexSbLsTer",
+          "name": "Flume",
+          "type": "artist",
+          "uri": "spotify:artist:6nxWCVXbOlEVRexSbLsTer"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 303660,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "AUFF01400535"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/24BYTj1tb5ovZcnIbtdTYD"
+      },
+      "href": "https://api.spotify.com/v1/tracks/24BYTj1tb5ovZcnIbtdTYD",
+      "id": "24BYTj1tb5ovZcnIbtdTYD",
+      "is_local": false,
+      "name": "Test & Recognise - Flume Re-work",
+      "popularity": 69,
+      "preview_url": "https://p.scdn.co/mp3-preview/d1c2c20b39cd8f9c37d277ae7c97b3989b718603?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:24BYTj1tb5ovZcnIbtdTYD"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1gMMbPTZtOb9W3IBYl6twO"
+            },
+            "href": "https://api.spotify.com/v1/artists/1gMMbPTZtOb9W3IBYl6twO",
+            "id": "1gMMbPTZtOb9W3IBYl6twO",
+            "name": "OLAN",
+            "type": "artist",
+            "uri": "spotify:artist:1gMMbPTZtOb9W3IBYl6twO"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4tSNagHpiYip5XqF3SZzAa"
+        },
+        "href": "https://api.spotify.com/v1/albums/4tSNagHpiYip5XqF3SZzAa",
+        "id": "4tSNagHpiYip5XqF3SZzAa",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2738c9cf43edc1a04a24e9e0df0",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e028c9cf43edc1a04a24e9e0df0",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048518c9cf43edc1a04a24e9e0df0",
+            "width": 64
+          }
+        ],
+        "name": "Promise To Keep",
+        "release_date": "2022-04-28",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:4tSNagHpiYip5XqF3SZzAa"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1gMMbPTZtOb9W3IBYl6twO"
+          },
+          "href": "https://api.spotify.com/v1/artists/1gMMbPTZtOb9W3IBYl6twO",
+          "id": "1gMMbPTZtOb9W3IBYl6twO",
+          "name": "OLAN",
+          "type": "artist",
+          "uri": "spotify:artist:1gMMbPTZtOb9W3IBYl6twO"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 288357,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2202044"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/3J8CjJWVaDbM9oE2XDyncj"
+      },
+      "href": "https://api.spotify.com/v1/tracks/3J8CjJWVaDbM9oE2XDyncj",
+      "id": "3J8CjJWVaDbM9oE2XDyncj",
+      "is_local": false,
+      "name": "Promise To Keep",
+      "popularity": 22,
+      "preview_url": "https://p.scdn.co/mp3-preview/61154c71031a178e8b7cdbd39eb01829549fc502?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:3J8CjJWVaDbM9oE2XDyncj"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+            },
+            "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+            "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+            "name": "Netsky",
+            "type": "artist",
+            "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/5RpkF55XZzzpWO0CnqcWw8"
+        },
+        "href": "https://api.spotify.com/v1/albums/5RpkF55XZzzpWO0CnqcWw8",
+        "id": "5RpkF55XZzzpWO0CnqcWw8",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273dcd9ab0c53e56eef188ea988",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02dcd9ab0c53e56eef188ea988",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851dcd9ab0c53e56eef188ea988",
+            "width": 64
+          }
+        ],
+        "name": "3",
+        "release_date": "2016-06-10",
+        "release_date_precision": "day",
+        "total_tracks": 12,
+        "type": "album",
+        "uri": "spotify:album:5RpkF55XZzzpWO0CnqcWw8"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+          },
+          "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+          "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+          "name": "Netsky",
+          "type": "artist",
+          "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3SvHrDiy9c35DFVnUysqkE"
+          },
+          "href": "https://api.spotify.com/v1/artists/3SvHrDiy9c35DFVnUysqkE",
+          "id": "3SvHrDiy9c35DFVnUysqkE",
+          "name": "Lowell",
+          "type": "artist",
+          "uri": "spotify:artist:3SvHrDiy9c35DFVnUysqkE"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 216960,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBARL1600152"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/518YAzM4k20EnkDvpJX1n8"
+      },
+      "href": "https://api.spotify.com/v1/tracks/518YAzM4k20EnkDvpJX1n8",
+      "id": "518YAzM4k20EnkDvpJX1n8",
+      "is_local": false,
+      "name": "Forget What You Look Like (feat. Lowell)",
+      "popularity": 37,
+      "preview_url": "https://p.scdn.co/mp3-preview/82791f64268fbc31dc17c1e57d5f5866039436c0?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 10,
+      "type": "track",
+      "uri": "spotify:track:518YAzM4k20EnkDvpJX1n8"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3XHO7cRUPCLOr6jwp8vsx5"
+            },
+            "href": "https://api.spotify.com/v1/artists/3XHO7cRUPCLOr6jwp8vsx5",
+            "id": "3XHO7cRUPCLOr6jwp8vsx5",
+            "name": "alt-J",
+            "type": "artist",
+            "uri": "spotify:artist:3XHO7cRUPCLOr6jwp8vsx5"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/39WJofoGKsqCZXKgORs1IP"
+        },
+        "href": "https://api.spotify.com/v1/albums/39WJofoGKsqCZXKgORs1IP",
+        "id": "39WJofoGKsqCZXKgORs1IP",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2734527d5b2468d0eed49d5326a",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e024527d5b2468d0eed49d5326a",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048514527d5b2468d0eed49d5326a",
+            "width": 64
+          }
+        ],
+        "name": "Deadcrush (Salute Remix)",
+        "release_date": "2017-08-30",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:39WJofoGKsqCZXKgORs1IP"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3XHO7cRUPCLOr6jwp8vsx5"
+          },
+          "href": "https://api.spotify.com/v1/artists/3XHO7cRUPCLOr6jwp8vsx5",
+          "id": "3XHO7cRUPCLOr6jwp8vsx5",
+          "name": "alt-J",
+          "type": "artist",
+          "uri": "spotify:artist:3XHO7cRUPCLOr6jwp8vsx5"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1np8xozf7ATJZDi9JX8Dx5"
+          },
+          "href": "https://api.spotify.com/v1/artists/1np8xozf7ATJZDi9JX8Dx5",
+          "id": "1np8xozf7ATJZDi9JX8Dx5",
+          "name": "salute",
+          "type": "artist",
+          "uri": "spotify:artist:1np8xozf7ATJZDi9JX8Dx5"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 258545,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB5KW1702661"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5KALNRc9mIMNPwHURxzJNw"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5KALNRc9mIMNPwHURxzJNw",
+      "id": "5KALNRc9mIMNPwHURxzJNw",
+      "is_local": false,
+      "name": "Deadcrush - Salute Remix",
+      "popularity": 29,
+      "preview_url": "https://p.scdn.co/mp3-preview/8f420987f57119a1331485163073e4ca11da0fb4?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5KALNRc9mIMNPwHURxzJNw"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6Ip8FS7vWT1uKkJSweANQK"
+            },
+            "href": "https://api.spotify.com/v1/artists/6Ip8FS7vWT1uKkJSweANQK",
+            "id": "6Ip8FS7vWT1uKkJSweANQK",
+            "name": "Dave",
+            "type": "artist",
+            "uri": "spotify:artist:6Ip8FS7vWT1uKkJSweANQK"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4GrFuXwRmEBJec22p58fsD"
+        },
+        "href": "https://api.spotify.com/v1/albums/4GrFuXwRmEBJec22p58fsD",
+        "id": "4GrFuXwRmEBJec22p58fsD",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273c1c8d2889455db6d03d309ed",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02c1c8d2889455db6d03d309ed",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851c1c8d2889455db6d03d309ed",
+            "width": 64
+          }
+        ],
+        "name": "PSYCHODRAMA",
+        "release_date": "2019-03-08",
+        "release_date_precision": "day",
+        "total_tracks": 11,
+        "type": "album",
+        "uri": "spotify:album:4GrFuXwRmEBJec22p58fsD"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6Ip8FS7vWT1uKkJSweANQK"
+          },
+          "href": "https://api.spotify.com/v1/artists/6Ip8FS7vWT1uKkJSweANQK",
+          "id": "6Ip8FS7vWT1uKkJSweANQK",
+          "name": "Dave",
+          "type": "artist",
+          "uri": "spotify:artist:6Ip8FS7vWT1uKkJSweANQK"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 202733,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBUM71900582"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7l1P6WtVtq1zQMq6qazNA4"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7l1P6WtVtq1zQMq6qazNA4",
+      "id": "7l1P6WtVtq1zQMq6qazNA4",
+      "is_local": false,
+      "name": "Environment",
+      "popularity": 59,
+      "preview_url": "https://p.scdn.co/mp3-preview/a95ce2335916f991d36d7239e91fd83d963586b1?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 8,
+      "type": "track",
+      "uri": "spotify:track:7l1P6WtVtq1zQMq6qazNA4"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/27gtK7m9vYwCyJ04zz0kIb"
+            },
+            "href": "https://api.spotify.com/v1/artists/27gtK7m9vYwCyJ04zz0kIb",
+            "id": "27gtK7m9vYwCyJ04zz0kIb",
+            "name": "Lane 8",
+            "type": "artist",
+            "uri": "spotify:artist:27gtK7m9vYwCyJ04zz0kIb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+            },
+            "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+            "id": "0g3NiCRhEv7M4SEDMrpItN",
+            "name": "Totally Enormous Extinct Dinosaurs",
+            "type": "artist",
+            "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/08fGtbr8PDy84u2KRrNuXS"
+        },
+        "href": "https://api.spotify.com/v1/albums/08fGtbr8PDy84u2KRrNuXS",
+        "id": "08fGtbr8PDy84u2KRrNuXS",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2731b05da207113150ccc039661",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e021b05da207113150ccc039661",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048511b05da207113150ccc039661",
+            "width": 64
+          }
+        ],
+        "name": "Reviver (Totally Enormous Extinct Dinosaurs Remix)",
+        "release_date": "2022-10-13",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:08fGtbr8PDy84u2KRrNuXS"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/27gtK7m9vYwCyJ04zz0kIb"
+          },
+          "href": "https://api.spotify.com/v1/artists/27gtK7m9vYwCyJ04zz0kIb",
+          "id": "27gtK7m9vYwCyJ04zz0kIb",
+          "name": "Lane 8",
+          "type": "artist",
+          "uri": "spotify:artist:27gtK7m9vYwCyJ04zz0kIb"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+          },
+          "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+          "id": "0g3NiCRhEv7M4SEDMrpItN",
+          "name": "Totally Enormous Extinct Dinosaurs",
+          "type": "artist",
+          "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 246000,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205680"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/0LAOGIAFvEnMnzrO5oaAb5"
+      },
+      "href": "https://api.spotify.com/v1/tracks/0LAOGIAFvEnMnzrO5oaAb5",
+      "id": "0LAOGIAFvEnMnzrO5oaAb5",
+      "is_local": false,
+      "name": "Reviver - Totally Enormous Extinct Dinosaurs Remix",
+      "popularity": 52,
+      "preview_url": "https://p.scdn.co/mp3-preview/d6a1c15940e615a31f4b849651ce74824e2af5e8?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:0LAOGIAFvEnMnzrO5oaAb5"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6qgnBH6iDM91ipVXv28OMu"
+            },
+            "href": "https://api.spotify.com/v1/artists/6qgnBH6iDM91ipVXv28OMu",
+            "id": "6qgnBH6iDM91ipVXv28OMu",
+            "name": "KAYTRANADA",
+            "type": "artist",
+            "uri": "spotify:artist:6qgnBH6iDM91ipVXv28OMu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6JD4Qerb8IcaAzFgpFw0sa"
+        },
+        "href": "https://api.spotify.com/v1/albums/6JD4Qerb8IcaAzFgpFw0sa",
+        "id": "6JD4Qerb8IcaAzFgpFw0sa",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2733016bbbbdf0825d3e4dc9aee",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e023016bbbbdf0825d3e4dc9aee",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048513016bbbbdf0825d3e4dc9aee",
+            "width": 64
+          }
+        ],
+        "name": "99.9%",
+        "release_date": "2016-05-06",
+        "release_date_precision": "day",
+        "total_tracks": 15,
+        "type": "album",
+        "uri": "spotify:album:6JD4Qerb8IcaAzFgpFw0sa"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6qgnBH6iDM91ipVXv28OMu"
+          },
+          "href": "https://api.spotify.com/v1/artists/6qgnBH6iDM91ipVXv28OMu",
+          "id": "6qgnBH6iDM91ipVXv28OMu",
+          "name": "KAYTRANADA",
+          "type": "artist",
+          "uri": "spotify:artist:6qgnBH6iDM91ipVXv28OMu"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5SyCTZ8X8YQCI0J1VRp4iC"
+          },
+          "href": "https://api.spotify.com/v1/artists/5SyCTZ8X8YQCI0J1VRp4iC",
+          "id": "5SyCTZ8X8YQCI0J1VRp4iC",
+          "name": "Phonte",
+          "type": "artist",
+          "uri": "spotify:artist:5SyCTZ8X8YQCI0J1VRp4iC"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 218240,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBBKS1600018"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/11jR36qzNpUnQ2YbMrru1p"
+      },
+      "href": "https://api.spotify.com/v1/tracks/11jR36qzNpUnQ2YbMrru1p",
+      "id": "11jR36qzNpUnQ2YbMrru1p",
+      "is_local": false,
+      "name": "ONE TOO MANY",
+      "popularity": 46,
+      "preview_url": "https://p.scdn.co/mp3-preview/b88ad6d50e810df88f8c977736aef1a94930fb47?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 7,
+      "type": "track",
+      "uri": "spotify:track:11jR36qzNpUnQ2YbMrru1p"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0SFtIrRytNI4kcf93Tbhdf"
+        },
+        "href": "https://api.spotify.com/v1/albums/0SFtIrRytNI4kcf93Tbhdf",
+        "id": "0SFtIrRytNI4kcf93Tbhdf",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a871bc3a84418ad1240a5d4e",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a871bc3a84418ad1240a5d4e",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a871bc3a84418ad1240a5d4e",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 2 (February 2 - October 15 2021)",
+        "release_date": "2021-11-19",
+        "release_date_precision": "day",
+        "total_tracks": 16,
+        "type": "album",
+        "uri": "spotify:album:0SFtIrRytNI4kcf93Tbhdf"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 250291,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2100378"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1uyQNwG1sFl7etjFTEHlQp"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1uyQNwG1sFl7etjFTEHlQp",
+      "id": "1uyQNwG1sFl7etjFTEHlQp",
+      "is_local": false,
+      "name": "Faisal (envelops me)",
+      "popularity": 55,
+      "preview_url": "https://p.scdn.co/mp3-preview/1195ac049c8e184d166c11416353dfa7d9a19b84?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 9,
+      "type": "track",
+      "uri": "spotify:track:1uyQNwG1sFl7etjFTEHlQp"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/7xni0tZQ8q2rTHkIeBYr1Y"
+        },
+        "href": "https://api.spotify.com/v1/albums/7xni0tZQ8q2rTHkIeBYr1Y",
+        "id": "7xni0tZQ8q2rTHkIeBYr1Y",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2733df0f9ce9536ac74c7aa4b98",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e023df0f9ce9536ac74c7aa4b98",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048513df0f9ce9536ac74c7aa4b98",
+            "width": 64
+          }
+        ],
+        "name": "Danielle (smile on my face)",
+        "release_date": "2022-09-14",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:7xni0tZQ8q2rTHkIeBYr1Y"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 201230,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBAHS2201033"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2sLVs5iX0osogh4jcsAJkv"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2sLVs5iX0osogh4jcsAJkv",
+      "id": "2sLVs5iX0osogh4jcsAJkv",
+      "is_local": false,
+      "name": "Danielle (smile on my face)",
+      "popularity": 72,
+      "preview_url": "https://p.scdn.co/mp3-preview/40db3affef1f922de542f146621f5155ac05c074?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:2sLVs5iX0osogh4jcsAJkv"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6vN8o7jyIAJvFPqC0vxxmm"
+        },
+        "href": "https://api.spotify.com/v1/albums/6vN8o7jyIAJvFPqC0vxxmm",
+        "id": "6vN8o7jyIAJvFPqC0vxxmm",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27356c393fab9a517cad09be7de",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0256c393fab9a517cad09be7de",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485156c393fab9a517cad09be7de",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 3 (January 1 - September 9 2022)",
+        "release_date": "2022-10-28",
+        "release_date_precision": "day",
+        "total_tracks": 13,
+        "type": "album",
+        "uri": "spotify:album:6vN8o7jyIAJvFPqC0vxxmm"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 238829,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201029"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5qJGp0cDrsOoRZOn75K6Y0"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5qJGp0cDrsOoRZOn75K6Y0",
+      "id": "5qJGp0cDrsOoRZOn75K6Y0",
+      "is_local": false,
+      "name": "Kammy (like i do)",
+      "popularity": 65,
+      "preview_url": "https://p.scdn.co/mp3-preview/a73494a7067ed82fc43ec776583358de9e9b5914?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 4,
+      "type": "track",
+      "uri": "spotify:track:5qJGp0cDrsOoRZOn75K6Y0"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6vN8o7jyIAJvFPqC0vxxmm"
+        },
+        "href": "https://api.spotify.com/v1/albums/6vN8o7jyIAJvFPqC0vxxmm",
+        "id": "6vN8o7jyIAJvFPqC0vxxmm",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27356c393fab9a517cad09be7de",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0256c393fab9a517cad09be7de",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485156c393fab9a517cad09be7de",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 3 (January 1 - September 9 2022)",
+        "release_date": "2022-10-28",
+        "release_date_precision": "day",
+        "total_tracks": 13,
+        "type": "album",
+        "uri": "spotify:album:6vN8o7jyIAJvFPqC0vxxmm"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 250702,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201028"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/67uX1e9gIoumz0U8ayaOiO"
+      },
+      "href": "https://api.spotify.com/v1/tracks/67uX1e9gIoumz0U8ayaOiO",
+      "id": "67uX1e9gIoumz0U8ayaOiO",
+      "is_local": false,
+      "name": "Delilah (pull me out of this)",
+      "popularity": 69,
+      "preview_url": "https://p.scdn.co/mp3-preview/fef5d52bd1f5ab14809ed022f06a2f0cda0f031a?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 3,
+      "type": "track",
+      "uri": "spotify:track:67uX1e9gIoumz0U8ayaOiO"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6vN8o7jyIAJvFPqC0vxxmm"
+        },
+        "href": "https://api.spotify.com/v1/albums/6vN8o7jyIAJvFPqC0vxxmm",
+        "id": "6vN8o7jyIAJvFPqC0vxxmm",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27356c393fab9a517cad09be7de",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0256c393fab9a517cad09be7de",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485156c393fab9a517cad09be7de",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 3 (January 1 - September 9 2022)",
+        "release_date": "2022-10-28",
+        "release_date_precision": "day",
+        "total_tracks": 13,
+        "type": "album",
+        "uri": "spotify:album:6vN8o7jyIAJvFPqC0vxxmm"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 210125,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201027"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7lCNgJUnROqgN9zIK0lx6a"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7lCNgJUnROqgN9zIK0lx6a",
+      "id": "7lCNgJUnROqgN9zIK0lx6a",
+      "is_local": false,
+      "name": "Eyelar (shutters)",
+      "popularity": 65,
+      "preview_url": "https://p.scdn.co/mp3-preview/1ac3ec945d940a701baa885b1f7503ccce40eb48?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:7lCNgJUnROqgN9zIK0lx6a"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Ma3pJzPIrAyYPNRkp3SUF"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Ma3pJzPIrAyYPNRkp3SUF",
+            "id": "1Ma3pJzPIrAyYPNRkp3SUF",
+            "name": "Ross from Friends",
+            "type": "artist",
+            "uri": "spotify:artist:1Ma3pJzPIrAyYPNRkp3SUF"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6c94J2yum9wHxmbSB27YXE"
+        },
+        "href": "https://api.spotify.com/v1/albums/6c94J2yum9wHxmbSB27YXE",
+        "id": "6c94J2yum9wHxmbSB27YXE",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273088d99c85e6de4f30b39679c",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02088d99c85e6de4f30b39679c",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851088d99c85e6de4f30b39679c",
+            "width": 64
+          }
+        ],
+        "name": "You'll Understand",
+        "release_date": "2017-02-10",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:6c94J2yum9wHxmbSB27YXE"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1Ma3pJzPIrAyYPNRkp3SUF"
+          },
+          "href": "https://api.spotify.com/v1/artists/1Ma3pJzPIrAyYPNRkp3SUF",
+          "id": "1Ma3pJzPIrAyYPNRkp3SUF",
+          "name": "Ross from Friends",
+          "type": "artist",
+          "uri": "spotify:artist:1Ma3pJzPIrAyYPNRkp3SUF"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 365968,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "UKA2G1608006"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/3mNXKbWX8ZAL8AW97dnoLq"
+      },
+      "href": "https://api.spotify.com/v1/tracks/3mNXKbWX8ZAL8AW97dnoLq",
+      "id": "3mNXKbWX8ZAL8AW97dnoLq",
+      "is_local": false,
+      "name": "Bootman",
+      "popularity": 44,
+      "preview_url": "https://p.scdn.co/mp3-preview/a7f323c73ca25bce33aad2aef6d20eecaa23223f?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 3,
+      "type": "track",
+      "uri": "spotify:track:3mNXKbWX8ZAL8AW97dnoLq"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+            "id": "5gqoUf9vKKv96b1c0GBKwu",
+            "name": "Dusky",
+            "type": "artist",
+            "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6QEnHZniqvybsckdyptQql"
+        },
+        "href": "https://api.spotify.com/v1/albums/6QEnHZniqvybsckdyptQql",
+        "id": "6QEnHZniqvybsckdyptQql",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2737a9e1bfb1e953cab106ac9e1",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e027a9e1bfb1e953cab106ac9e1",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048517a9e1bfb1e953cab106ac9e1",
+            "width": 64
+          }
+        ],
+        "name": "Pressure",
+        "release_date": "2022-10-07",
+        "release_date_precision": "day",
+        "total_tracks": 11,
+        "type": "album",
+        "uri": "spotify:album:6QEnHZniqvybsckdyptQql"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+          },
+          "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+          "id": "5gqoUf9vKKv96b1c0GBKwu",
+          "name": "Dusky",
+          "type": "artist",
+          "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 215222,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205641"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/4xoYQAad9OYlNy7cASMNuS"
+      },
+      "href": "https://api.spotify.com/v1/tracks/4xoYQAad9OYlNy7cASMNuS",
+      "id": "4xoYQAad9OYlNy7cASMNuS",
+      "is_local": false,
+      "name": "Rollers",
+      "popularity": 29,
+      "preview_url": "https://p.scdn.co/mp3-preview/d729a369beb3c9a212a0ecbbf33e310dedb1f57c?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 7,
+      "type": "track",
+      "uri": "spotify:track:4xoYQAad9OYlNy7cASMNuS"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5fMUXHkw8R8eOP2RNVYEZX"
+            },
+            "href": "https://api.spotify.com/v1/artists/5fMUXHkw8R8eOP2RNVYEZX",
+            "id": "5fMUXHkw8R8eOP2RNVYEZX",
+            "name": "Diplo",
+            "type": "artist",
+            "uri": "spotify:artist:5fMUXHkw8R8eOP2RNVYEZX"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4CA8PTrbq1l5IgyvBA2JSV"
+            },
+            "href": "https://api.spotify.com/v1/artists/4CA8PTrbq1l5IgyvBA2JSV",
+            "id": "4CA8PTrbq1l5IgyvBA2JSV",
+            "name": "Paul Woolford",
+            "type": "artist",
+            "uri": "spotify:artist:4CA8PTrbq1l5IgyvBA2JSV"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0Fb9qTWnjsB90xH3zWr4oa"
+            },
+            "href": "https://api.spotify.com/v1/artists/0Fb9qTWnjsB90xH3zWr4oa",
+            "id": "0Fb9qTWnjsB90xH3zWr4oa",
+            "name": "Kareen Lomax",
+            "type": "artist",
+            "uri": "spotify:artist:0Fb9qTWnjsB90xH3zWr4oa"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2pNtsyHd2CL7XM6PtwoOyG"
+        },
+        "href": "https://api.spotify.com/v1/albums/2pNtsyHd2CL7XM6PtwoOyG",
+        "id": "2pNtsyHd2CL7XM6PtwoOyG",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2738cfebe40bb99af0a25537788",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e028cfebe40bb99af0a25537788",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048518cfebe40bb99af0a25537788",
+            "width": 64
+          }
+        ],
+        "name": "Promises",
+        "release_date": "2021-09-28",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:2pNtsyHd2CL7XM6PtwoOyG"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5fMUXHkw8R8eOP2RNVYEZX"
+          },
+          "href": "https://api.spotify.com/v1/artists/5fMUXHkw8R8eOP2RNVYEZX",
+          "id": "5fMUXHkw8R8eOP2RNVYEZX",
+          "name": "Diplo",
+          "type": "artist",
+          "uri": "spotify:artist:5fMUXHkw8R8eOP2RNVYEZX"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4CA8PTrbq1l5IgyvBA2JSV"
+          },
+          "href": "https://api.spotify.com/v1/artists/4CA8PTrbq1l5IgyvBA2JSV",
+          "id": "4CA8PTrbq1l5IgyvBA2JSV",
+          "name": "Paul Woolford",
+          "type": "artist",
+          "uri": "spotify:artist:4CA8PTrbq1l5IgyvBA2JSV"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0Fb9qTWnjsB90xH3zWr4oa"
+          },
+          "href": "https://api.spotify.com/v1/artists/0Fb9qTWnjsB90xH3zWr4oa",
+          "id": "0Fb9qTWnjsB90xH3zWr4oa",
+          "name": "Kareen Lomax",
+          "type": "artist",
+          "uri": "spotify:artist:0Fb9qTWnjsB90xH3zWr4oa"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 201176,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USZ4V2100192"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/50YQaQXog18lS11wGCl77u"
+      },
+      "href": "https://api.spotify.com/v1/tracks/50YQaQXog18lS11wGCl77u",
+      "id": "50YQaQXog18lS11wGCl77u",
+      "is_local": false,
+      "name": "Promises",
+      "popularity": 50,
+      "preview_url": "https://p.scdn.co/mp3-preview/a44d6ebaf77727f26095991c81b295543bac345b?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:50YQaQXog18lS11wGCl77u"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0CkbPVBpOwwz9NPPglFKyq"
+            },
+            "href": "https://api.spotify.com/v1/artists/0CkbPVBpOwwz9NPPglFKyq",
+            "id": "0CkbPVBpOwwz9NPPglFKyq",
+            "name": "RAY BLK",
+            "type": "artist",
+            "uri": "spotify:artist:0CkbPVBpOwwz9NPPglFKyq"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2A9YfiOYh4jJ7qsLeUdnDM"
+        },
+        "href": "https://api.spotify.com/v1/albums/2A9YfiOYh4jJ7qsLeUdnDM",
+        "id": "2A9YfiOYh4jJ7qsLeUdnDM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273456f28858603774693ccd632",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02456f28858603774693ccd632",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851456f28858603774693ccd632",
+            "width": 64
+          }
+        ],
+        "name": "Durt",
+        "release_date": "2016-10-27",
+        "release_date_precision": "day",
+        "total_tracks": 7,
+        "type": "album",
+        "uri": "spotify:album:2A9YfiOYh4jJ7qsLeUdnDM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0CkbPVBpOwwz9NPPglFKyq"
+          },
+          "href": "https://api.spotify.com/v1/artists/0CkbPVBpOwwz9NPPglFKyq",
+          "id": "0CkbPVBpOwwz9NPPglFKyq",
+          "name": "RAY BLK",
+          "type": "artist",
+          "uri": "spotify:artist:0CkbPVBpOwwz9NPPglFKyq"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2SrSdSvpminqmStGELCSNd"
+          },
+          "href": "https://api.spotify.com/v1/artists/2SrSdSvpminqmStGELCSNd",
+          "id": "2SrSdSvpminqmStGELCSNd",
+          "name": "Stormzy",
+          "type": "artist",
+          "uri": "spotify:artist:2SrSdSvpminqmStGELCSNd"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 271956,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "FR2X41642772"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5IeuKkd8EE5prwJX77iW03"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5IeuKkd8EE5prwJX77iW03",
+      "id": "5IeuKkd8EE5prwJX77iW03",
+      "is_local": false,
+      "name": "My Hood",
+      "popularity": 45,
+      "preview_url": "https://p.scdn.co/mp3-preview/af953907161339f405626311f5b8b2bd09116d0f?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 6,
+      "type": "track",
+      "uri": "spotify:track:5IeuKkd8EE5prwJX77iW03"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6nxWCVXbOlEVRexSbLsTer"
+            },
+            "href": "https://api.spotify.com/v1/artists/6nxWCVXbOlEVRexSbLsTer",
+            "id": "6nxWCVXbOlEVRexSbLsTer",
+            "name": "Flume",
+            "type": "artist",
+            "uri": "spotify:artist:6nxWCVXbOlEVRexSbLsTer"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2NUSMc4rQ9jjUFE3PnhKBO"
+        },
+        "href": "https://api.spotify.com/v1/albums/2NUSMc4rQ9jjUFE3PnhKBO",
+        "id": "2NUSMc4rQ9jjUFE3PnhKBO",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2739395c17791d868238377273a",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e029395c17791d868238377273a",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048519395c17791d868238377273a",
+            "width": 64
+          }
+        ],
+        "name": "Skin Companion EP II",
+        "release_date": "2017-02-17",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:2NUSMc4rQ9jjUFE3PnhKBO"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6nxWCVXbOlEVRexSbLsTer"
+          },
+          "href": "https://api.spotify.com/v1/artists/6nxWCVXbOlEVRexSbLsTer",
+          "id": "6nxWCVXbOlEVRexSbLsTer",
+          "name": "Flume",
+          "type": "artist",
+          "uri": "spotify:artist:6nxWCVXbOlEVRexSbLsTer"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5W10uJRsbt9bROJDKoI1Wn"
+          },
+          "href": "https://api.spotify.com/v1/artists/5W10uJRsbt9bROJDKoI1Wn",
+          "id": "5W10uJRsbt9bROJDKoI1Wn",
+          "name": "Moses Sumney",
+          "type": "artist",
+          "uri": "spotify:artist:5W10uJRsbt9bROJDKoI1Wn"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 259176,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "AUFF01700018"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/71CPVF1Z2fWQz4fMfpGsXC"
+      },
+      "href": "https://api.spotify.com/v1/tracks/71CPVF1Z2fWQz4fMfpGsXC",
+      "id": "71CPVF1Z2fWQz4fMfpGsXC",
+      "is_local": false,
+      "name": "Weekend",
+      "popularity": 35,
+      "preview_url": "https://p.scdn.co/mp3-preview/c16bc45ec58b2d6400625a0c9b91cbb1af030562?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:71CPVF1Z2fWQz4fMfpGsXC"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/73A3bLnfnz5BoQjb4gNCga"
+            },
+            "href": "https://api.spotify.com/v1/artists/73A3bLnfnz5BoQjb4gNCga",
+            "id": "73A3bLnfnz5BoQjb4gNCga",
+            "name": "Bicep",
+            "type": "artist",
+            "uri": "spotify:artist:73A3bLnfnz5BoQjb4gNCga"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6ZgM0jM6nRUlK6wRXEONVc"
+        },
+        "href": "https://api.spotify.com/v1/albums/6ZgM0jM6nRUlK6wRXEONVc",
+        "id": "6ZgM0jM6nRUlK6wRXEONVc",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a52a69cf3de74cbc7f16f2a8",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a52a69cf3de74cbc7f16f2a8",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a52a69cf3de74cbc7f16f2a8",
+            "width": 64
+          }
+        ],
+        "name": "Apricots",
+        "release_date": "2020-10-06",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:6ZgM0jM6nRUlK6wRXEONVc"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/73A3bLnfnz5BoQjb4gNCga"
+          },
+          "href": "https://api.spotify.com/v1/artists/73A3bLnfnz5BoQjb4gNCga",
+          "id": "73A3bLnfnz5BoQjb4gNCga",
+          "name": "Bicep",
+          "type": "artist",
+          "uri": "spotify:artist:73A3bLnfnz5BoQjb4gNCga"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 246506,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBCFB2000317"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/73X9X7kDgsm4YeHpc8prf6"
+      },
+      "href": "https://api.spotify.com/v1/tracks/73X9X7kDgsm4YeHpc8prf6",
+      "id": "73X9X7kDgsm4YeHpc8prf6",
+      "is_local": false,
+      "name": "Apricots",
+      "popularity": 52,
+      "preview_url": "https://p.scdn.co/mp3-preview/b223277b823fa66ab8c28630b6770b46d7e5d0d0?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:73X9X7kDgsm4YeHpc8prf6"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1WgXqy2Dd70QQOU7Ay074N"
+            },
+            "href": "https://api.spotify.com/v1/artists/1WgXqy2Dd70QQOU7Ay074N",
+            "id": "1WgXqy2Dd70QQOU7Ay074N",
+            "name": "AURORA",
+            "type": "artist",
+            "uri": "spotify:artist:1WgXqy2Dd70QQOU7Ay074N"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6kMFIRSHhvcwczeyyYqDMb"
+        },
+        "href": "https://api.spotify.com/v1/albums/6kMFIRSHhvcwczeyyYqDMb",
+        "id": "6kMFIRSHhvcwczeyyYqDMb",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f26cea9588f13dacc69378d8",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f26cea9588f13dacc69378d8",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f26cea9588f13dacc69378d8",
+            "width": 64
+          }
+        ],
+        "name": "Queendom (Remixes)",
+        "release_date": "2018-06-29",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:6kMFIRSHhvcwczeyyYqDMb"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1WgXqy2Dd70QQOU7Ay074N"
+          },
+          "href": "https://api.spotify.com/v1/artists/1WgXqy2Dd70QQOU7Ay074N",
+          "id": "1WgXqy2Dd70QQOU7Ay074N",
+          "name": "AURORA",
+          "type": "artist",
+          "uri": "spotify:artist:1WgXqy2Dd70QQOU7Ay074N"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7nc2JTIfR3eZwXeq3pbwt2"
+          },
+          "href": "https://api.spotify.com/v1/artists/7nc2JTIfR3eZwXeq3pbwt2",
+          "id": "7nc2JTIfR3eZwXeq3pbwt2",
+          "name": "B.Traits",
+          "type": "artist",
+          "uri": "spotify:artist:7nc2JTIfR3eZwXeq3pbwt2"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 503786,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBUM71802864"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1ObfZmvPZcdowxfaR9qFUS"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1ObfZmvPZcdowxfaR9qFUS",
+      "id": "1ObfZmvPZcdowxfaR9qFUS",
+      "is_local": false,
+      "name": "Queendom - B.Traits Remix",
+      "popularity": 17,
+      "preview_url": "https://p.scdn.co/mp3-preview/d82bf52001e61f6453de4ee2659f685292330582?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:1ObfZmvPZcdowxfaR9qFUS"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6TshTCYwh9ySzOO6Jy4Ux2"
+            },
+            "href": "https://api.spotify.com/v1/artists/6TshTCYwh9ySzOO6Jy4Ux2",
+            "id": "6TshTCYwh9ySzOO6Jy4Ux2",
+            "name": "Maya Jane Coles",
+            "type": "artist",
+            "uri": "spotify:artist:6TshTCYwh9ySzOO6Jy4Ux2"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0DECxh5mdTBhB2Rw9qE7UI"
+        },
+        "href": "https://api.spotify.com/v1/albums/0DECxh5mdTBhB2Rw9qE7UI",
+        "id": "0DECxh5mdTBhB2Rw9qE7UI",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2735fc235dac602275bcfb0c869",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e025fc235dac602275bcfb0c869",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048515fc235dac602275bcfb0c869",
+            "width": 64
+          }
+        ],
+        "name": "What They Say EP",
+        "release_date": "2010-09-22",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:0DECxh5mdTBhB2Rw9qE7UI"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6TshTCYwh9ySzOO6Jy4Ux2"
+          },
+          "href": "https://api.spotify.com/v1/artists/6TshTCYwh9ySzOO6Jy4Ux2",
+          "id": "6TshTCYwh9ySzOO6Jy4Ux2",
+          "name": "Maya Jane Coles",
+          "type": "artist",
+          "uri": "spotify:artist:6TshTCYwh9ySzOO6Jy4Ux2"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 400115,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKPL1417035"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5S7Y5HgQ2HPqiCVkKylT2r"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5S7Y5HgQ2HPqiCVkKylT2r",
+      "id": "5S7Y5HgQ2HPqiCVkKylT2r",
+      "is_local": false,
+      "name": "What They Say",
+      "popularity": 44,
+      "preview_url": "https://p.scdn.co/mp3-preview/1fe80f31d2914376562a7b2b896d63d5ae15c9ec?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5S7Y5HgQ2HPqiCVkKylT2r"
+    }
+  ],
+  "limit": 50,
+  "next": null,
+  "offset": 0,
+  "previous": null,
+  "total": 50
+}

--- a/tests/flat_files/json/spotify/v1/me/top/tracks/time_range=medium_term&limit=50.json
+++ b/tests/flat_files/json/spotify/v1/me/top/tracks/time_range=medium_term&limit=50.json
@@ -1,0 +1,4350 @@
+{
+  "href": "https://api.spotify.com/v1/me/top/tracks?limit=50&offset=0&time_range=short_term",
+  "items": [
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+            "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+            "name": "venbee",
+            "type": "artist",
+            "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tfGcCoLFmUtfhgB9sREHq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tfGcCoLFmUtfhgB9sREHq",
+            "id": "4tfGcCoLFmUtfhgB9sREHq",
+            "name": "Dan Fable",
+            "type": "artist",
+            "uri": "spotify:artist:4tfGcCoLFmUtfhgB9sREHq"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/48KWh33PB86WJeyFhQOkVl"
+        },
+        "href": "https://api.spotify.com/v1/albums/48KWh33PB86WJeyFhQOkVl",
+        "id": "48KWh33PB86WJeyFhQOkVl",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2736e0759c0137223701e4f4c3b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e026e0759c0137223701e4f4c3b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048516e0759c0137223701e4f4c3b",
+            "width": 64
+          }
+        ],
+        "name": "low down",
+        "release_date": "2022-05-23",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:48KWh33PB86WJeyFhQOkVl"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+          "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+          "name": "venbee",
+          "type": "artist",
+          "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4tfGcCoLFmUtfhgB9sREHq"
+          },
+          "href": "https://api.spotify.com/v1/artists/4tfGcCoLFmUtfhgB9sREHq",
+          "id": "4tfGcCoLFmUtfhgB9sREHq",
+          "name": "Dan Fable",
+          "type": "artist",
+          "uri": "spotify:artist:4tfGcCoLFmUtfhgB9sREHq"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 182923,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "QZES92294424"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5hwQBJojbljFjxg7t49r03"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5hwQBJojbljFjxg7t49r03",
+      "id": "5hwQBJojbljFjxg7t49r03",
+      "is_local": false,
+      "name": "low down",
+      "popularity": 67,
+      "preview_url": "https://p.scdn.co/mp3-preview/9af09320dc7793d2c5eb373b7374ca10db145385?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5hwQBJojbljFjxg7t49r03"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+            },
+            "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+            "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+            "name": "venbee",
+            "type": "artist",
+            "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3yDDYheQFqfhKZXdjFQuuP"
+            },
+            "href": "https://api.spotify.com/v1/artists/3yDDYheQFqfhKZXdjFQuuP",
+            "id": "3yDDYheQFqfhKZXdjFQuuP",
+            "name": "goddard.",
+            "type": "artist",
+            "uri": "spotify:artist:3yDDYheQFqfhKZXdjFQuuP"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0a9uNlopPXGg37OC20qDk6"
+        },
+        "href": "https://api.spotify.com/v1/albums/0a9uNlopPXGg37OC20qDk6",
+        "id": "0a9uNlopPXGg37OC20qDk6",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27302402656bca0b5b39489f39a",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0202402656bca0b5b39489f39a",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485102402656bca0b5b39489f39a",
+            "width": 64
+          }
+        ],
+        "name": "messy in heaven",
+        "release_date": "2022-09-23",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:0a9uNlopPXGg37OC20qDk6"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4UWWa5dKgTLAx8mv6Ju6X1"
+          },
+          "href": "https://api.spotify.com/v1/artists/4UWWa5dKgTLAx8mv6Ju6X1",
+          "id": "4UWWa5dKgTLAx8mv6Ju6X1",
+          "name": "venbee",
+          "type": "artist",
+          "uri": "spotify:artist:4UWWa5dKgTLAx8mv6Ju6X1"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3yDDYheQFqfhKZXdjFQuuP"
+          },
+          "href": "https://api.spotify.com/v1/artists/3yDDYheQFqfhKZXdjFQuuP",
+          "id": "3yDDYheQFqfhKZXdjFQuuP",
+          "name": "goddard.",
+          "type": "artist",
+          "uri": "spotify:artist:3yDDYheQFqfhKZXdjFQuuP"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 170437,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBARL2201891"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5RobAV5ROH5KARimi7n3cO"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5RobAV5ROH5KARimi7n3cO",
+      "id": "5RobAV5ROH5KARimi7n3cO",
+      "is_local": false,
+      "name": "messy in heaven",
+      "popularity": 76,
+      "preview_url": "https://p.scdn.co/mp3-preview/39f0684b09b7b6e48c93f1fc9f89b2fdec8cef22?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5RobAV5ROH5KARimi7n3cO"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4frXpPxQQZwbCu3eTGnZEw"
+            },
+            "href": "https://api.spotify.com/v1/artists/4frXpPxQQZwbCu3eTGnZEw",
+            "id": "4frXpPxQQZwbCu3eTGnZEw",
+            "name": "Thundercat",
+            "type": "artist",
+            "uri": "spotify:artist:4frXpPxQQZwbCu3eTGnZEw"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/7vHBQDqwzB7uDvoE5bncMM"
+        },
+        "href": "https://api.spotify.com/v1/albums/7vHBQDqwzB7uDvoE5bncMM",
+        "id": "7vHBQDqwzB7uDvoE5bncMM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27385c5e6c686ced3e43bae2748",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0285c5e6c686ced3e43bae2748",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485185c5e6c686ced3e43bae2748",
+            "width": 64
+          }
+        ],
+        "name": "Drunk",
+        "release_date": "2017-02-24",
+        "release_date_precision": "day",
+        "total_tracks": 23,
+        "type": "album",
+        "uri": "spotify:album:7vHBQDqwzB7uDvoE5bncMM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4frXpPxQQZwbCu3eTGnZEw"
+          },
+          "href": "https://api.spotify.com/v1/artists/4frXpPxQQZwbCu3eTGnZEw",
+          "id": "4frXpPxQQZwbCu3eTGnZEw",
+          "name": "Thundercat",
+          "type": "artist",
+          "uri": "spotify:artist:4frXpPxQQZwbCu3eTGnZEw"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 188453,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "US25X1090547"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7CH99b2i1TXS5P8UUyWtnM"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7CH99b2i1TXS5P8UUyWtnM",
+      "id": "7CH99b2i1TXS5P8UUyWtnM",
+      "is_local": false,
+      "name": "Them Changes",
+      "popularity": 79,
+      "preview_url": "https://p.scdn.co/mp3-preview/c9a76d20b277680af25d9b920cb03a2412135003?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 15,
+      "type": "track",
+      "uri": "spotify:track:7CH99b2i1TXS5P8UUyWtnM"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+            "id": "5gqoUf9vKKv96b1c0GBKwu",
+            "name": "Dusky",
+            "type": "artist",
+            "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1zJORUI9CgL3QHBhRqy0OM"
+        },
+        "href": "https://api.spotify.com/v1/albums/1zJORUI9CgL3QHBhRqy0OM",
+        "id": "1zJORUI9CgL3QHBhRqy0OM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273eb6412542b6e16fc44261405",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02eb6412542b6e16fc44261405",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851eb6412542b6e16fc44261405",
+            "width": 64
+          }
+        ],
+        "name": "Lonely Dulcimer / In Effect",
+        "release_date": "2022-09-16",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:1zJORUI9CgL3QHBhRqy0OM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+          },
+          "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+          "id": "5gqoUf9vKKv96b1c0GBKwu",
+          "name": "Dusky",
+          "type": "artist",
+          "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 193741,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205190"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5vY3kwXfrDxNu8XzsbMhZi"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5vY3kwXfrDxNu8XzsbMhZi",
+      "id": "5vY3kwXfrDxNu8XzsbMhZi",
+      "is_local": false,
+      "name": "Lonely Dulcimer",
+      "popularity": 42,
+      "preview_url": "https://p.scdn.co/mp3-preview/535d9dc0e39d2a975617454328eb930ea2842e0f?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5vY3kwXfrDxNu8XzsbMhZi"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0iTjLBepeGaLgZS18kxgRq"
+            },
+            "href": "https://api.spotify.com/v1/artists/0iTjLBepeGaLgZS18kxgRq",
+            "id": "0iTjLBepeGaLgZS18kxgRq",
+            "name": "Oliver Schories",
+            "type": "artist",
+            "uri": "spotify:artist:0iTjLBepeGaLgZS18kxgRq"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5wMlMjOLeJfS5DfxqGfm83"
+            },
+            "href": "https://api.spotify.com/v1/artists/5wMlMjOLeJfS5DfxqGfm83",
+            "id": "5wMlMjOLeJfS5DfxqGfm83",
+            "name": "Jan Blomqvist",
+            "type": "artist",
+            "uri": "spotify:artist:5wMlMjOLeJfS5DfxqGfm83"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2N1lWGpmve4vfMTGeCk3At"
+        },
+        "href": "https://api.spotify.com/v1/albums/2N1lWGpmve4vfMTGeCk3At",
+        "id": "2N1lWGpmve4vfMTGeCk3At",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273844cab1b3286d8b06e219311",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02844cab1b3286d8b06e219311",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851844cab1b3286d8b06e219311",
+            "width": 64
+          }
+        ],
+        "name": "Packard",
+        "release_date": "2020-06-19",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:2N1lWGpmve4vfMTGeCk3At"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0iTjLBepeGaLgZS18kxgRq"
+          },
+          "href": "https://api.spotify.com/v1/artists/0iTjLBepeGaLgZS18kxgRq",
+          "id": "0iTjLBepeGaLgZS18kxgRq",
+          "name": "Oliver Schories",
+          "type": "artist",
+          "uri": "spotify:artist:0iTjLBepeGaLgZS18kxgRq"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5wMlMjOLeJfS5DfxqGfm83"
+          },
+          "href": "https://api.spotify.com/v1/artists/5wMlMjOLeJfS5DfxqGfm83",
+          "id": "5wMlMjOLeJfS5DfxqGfm83",
+          "name": "Jan Blomqvist",
+          "type": "artist",
+          "uri": "spotify:artist:5wMlMjOLeJfS5DfxqGfm83"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 361281,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "DEY472083912"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/68UiApRTyu4Trb5kwMgCd2"
+      },
+      "href": "https://api.spotify.com/v1/tracks/68UiApRTyu4Trb5kwMgCd2",
+      "id": "68UiApRTyu4Trb5kwMgCd2",
+      "is_local": false,
+      "name": "Packard - Blomqvist & Schories Sunrise Mix",
+      "popularity": 45,
+      "preview_url": "https://p.scdn.co/mp3-preview/3fe9da983900e01de2a292e69b84a05f28146124?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:68UiApRTyu4Trb5kwMgCd2"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+            "id": "5gqoUf9vKKv96b1c0GBKwu",
+            "name": "Dusky",
+            "type": "artist",
+            "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6QEnHZniqvybsckdyptQql"
+        },
+        "href": "https://api.spotify.com/v1/albums/6QEnHZniqvybsckdyptQql",
+        "id": "6QEnHZniqvybsckdyptQql",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2737a9e1bfb1e953cab106ac9e1",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e027a9e1bfb1e953cab106ac9e1",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048517a9e1bfb1e953cab106ac9e1",
+            "width": 64
+          }
+        ],
+        "name": "Pressure",
+        "release_date": "2022-10-07",
+        "release_date_precision": "day",
+        "total_tracks": 11,
+        "type": "album",
+        "uri": "spotify:album:6QEnHZniqvybsckdyptQql"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+          },
+          "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+          "id": "5gqoUf9vKKv96b1c0GBKwu",
+          "name": "Dusky",
+          "type": "artist",
+          "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 209685,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205460"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2PuJiEG6QCfOCmrbjLepgr"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2PuJiEG6QCfOCmrbjLepgr",
+      "id": "2PuJiEG6QCfOCmrbjLepgr",
+      "is_local": false,
+      "name": "Northbound",
+      "popularity": 33,
+      "preview_url": "https://p.scdn.co/mp3-preview/6383e9659da368a858c9177371ff874b00e8cef4?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 4,
+      "type": "track",
+      "uri": "spotify:track:2PuJiEG6QCfOCmrbjLepgr"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2avRYQUWQpIkzJOEkf0MdY"
+            },
+            "href": "https://api.spotify.com/v1/artists/2avRYQUWQpIkzJOEkf0MdY",
+            "id": "2avRYQUWQpIkzJOEkf0MdY",
+            "name": "Kx5",
+            "type": "artist",
+            "uri": "spotify:artist:2avRYQUWQpIkzJOEkf0MdY"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+            },
+            "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+            "id": "2CIMQHirSU0MQqyYHq0eOx",
+            "name": "deadmau5",
+            "type": "artist",
+            "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6TQj5BFPooTa08A7pk8AQ1"
+            },
+            "href": "https://api.spotify.com/v1/artists/6TQj5BFPooTa08A7pk8AQ1",
+            "id": "6TQj5BFPooTa08A7pk8AQ1",
+            "name": "Kaskade",
+            "type": "artist",
+            "uri": "spotify:artist:6TQj5BFPooTa08A7pk8AQ1"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/5nTSB1dEcWtAtkWnHgOcMR"
+        },
+        "href": "https://api.spotify.com/v1/albums/5nTSB1dEcWtAtkWnHgOcMR",
+        "id": "5nTSB1dEcWtAtkWnHgOcMR",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2733257a0ad4aa2ccad6a24908b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e023257a0ad4aa2ccad6a24908b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048513257a0ad4aa2ccad6a24908b",
+            "width": 64
+          }
+        ],
+        "name": "Alive (feat. The Moth & The Flame)",
+        "release_date": "2022-10-11",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:5nTSB1dEcWtAtkWnHgOcMR"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2avRYQUWQpIkzJOEkf0MdY"
+          },
+          "href": "https://api.spotify.com/v1/artists/2avRYQUWQpIkzJOEkf0MdY",
+          "id": "2avRYQUWQpIkzJOEkf0MdY",
+          "name": "Kx5",
+          "type": "artist",
+          "uri": "spotify:artist:2avRYQUWQpIkzJOEkf0MdY"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+          },
+          "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+          "id": "2CIMQHirSU0MQqyYHq0eOx",
+          "name": "deadmau5",
+          "type": "artist",
+          "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6TQj5BFPooTa08A7pk8AQ1"
+          },
+          "href": "https://api.spotify.com/v1/artists/6TQj5BFPooTa08A7pk8AQ1",
+          "id": "6TQj5BFPooTa08A7pk8AQ1",
+          "name": "Kaskade",
+          "type": "artist",
+          "uri": "spotify:artist:6TQj5BFPooTa08A7pk8AQ1"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6Fk18HpdnXUsKWpN9mPb9R"
+          },
+          "href": "https://api.spotify.com/v1/artists/6Fk18HpdnXUsKWpN9mPb9R",
+          "id": "6Fk18HpdnXUsKWpN9mPb9R",
+          "name": "The Moth & The Flame",
+          "type": "artist",
+          "uri": "spotify:artist:6Fk18HpdnXUsKWpN9mPb9R"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 308709,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBTDG1302561"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1SETgPENHVzsWoD9g79LYI"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1SETgPENHVzsWoD9g79LYI",
+      "id": "1SETgPENHVzsWoD9g79LYI",
+      "is_local": false,
+      "name": "Alive (feat. The Moth & The Flame)",
+      "popularity": 64,
+      "preview_url": "https://p.scdn.co/mp3-preview/3cb22178dbea5cccf38c9b8b266ae73c517cb3ec?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1SETgPENHVzsWoD9g79LYI"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0ynzbXwyCzxicMKHBoOkSH"
+            },
+            "href": "https://api.spotify.com/v1/artists/0ynzbXwyCzxicMKHBoOkSH",
+            "id": "0ynzbXwyCzxicMKHBoOkSH",
+            "name": "EKKSTACY",
+            "type": "artist",
+            "uri": "spotify:artist:0ynzbXwyCzxicMKHBoOkSH"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6tdl27ojBwZ5ZexzZOP4mG"
+        },
+        "href": "https://api.spotify.com/v1/albums/6tdl27ojBwZ5ZexzZOP4mG",
+        "id": "6tdl27ojBwZ5ZexzZOP4mG",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27357f165027c8170e37e526b86",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0257f165027c8170e37e526b86",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485157f165027c8170e37e526b86",
+            "width": 64
+          }
+        ],
+        "name": "i walk this earth all by myself",
+        "release_date": "2021-03-05",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:6tdl27ojBwZ5ZexzZOP4mG"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0ynzbXwyCzxicMKHBoOkSH"
+          },
+          "href": "https://api.spotify.com/v1/artists/0ynzbXwyCzxicMKHBoOkSH",
+          "id": "0ynzbXwyCzxicMKHBoOkSH",
+          "name": "EKKSTACY",
+          "type": "artist",
+          "uri": "spotify:artist:0ynzbXwyCzxicMKHBoOkSH"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 145634,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "QZNMU2174737"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5a8QUc4ubHJqQm7vzs2YhA"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5a8QUc4ubHJqQm7vzs2YhA",
+      "id": "5a8QUc4ubHJqQm7vzs2YhA",
+      "is_local": false,
+      "name": "i walk this earth all by myself",
+      "popularity": 71,
+      "preview_url": "https://p.scdn.co/mp3-preview/34c27a848aa3a3e4387408d8e15ef0fc61f696df?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5a8QUc4ubHJqQm7vzs2YhA"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1BqIPGrEhdjdLFpUzce2dh"
+            },
+            "href": "https://api.spotify.com/v1/artists/1BqIPGrEhdjdLFpUzce2dh",
+            "id": "1BqIPGrEhdjdLFpUzce2dh",
+            "name": "Durante",
+            "type": "artist",
+            "uri": "spotify:artist:1BqIPGrEhdjdLFpUzce2dh"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/3drFZq7mJtUkGEq5duNBAM"
+        },
+        "href": "https://api.spotify.com/v1/albums/3drFZq7mJtUkGEq5duNBAM",
+        "id": "3drFZq7mJtUkGEq5duNBAM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273b4ef320f98f3a28f5262a79b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02b4ef320f98f3a28f5262a79b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851b4ef320f98f3a28f5262a79b",
+            "width": 64
+          }
+        ],
+        "name": "Unraveled",
+        "release_date": "2017-11-24",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:3drFZq7mJtUkGEq5duNBAM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1BqIPGrEhdjdLFpUzce2dh"
+          },
+          "href": "https://api.spotify.com/v1/artists/1BqIPGrEhdjdLFpUzce2dh",
+          "id": "1BqIPGrEhdjdLFpUzce2dh",
+          "name": "Durante",
+          "type": "artist",
+          "uri": "spotify:artist:1BqIPGrEhdjdLFpUzce2dh"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 334761,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USYBL1701677"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2DxlImGfZPKLLhqqEl1nbW"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2DxlImGfZPKLLhqqEl1nbW",
+      "id": "2DxlImGfZPKLLhqqEl1nbW",
+      "is_local": false,
+      "name": "Split Wick",
+      "popularity": 42,
+      "preview_url": "https://p.scdn.co/mp3-preview/ee9313f8c849a1163514f399f820731c9c49efde?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:2DxlImGfZPKLLhqqEl1nbW"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6nneI0xOh7SR2zvzHcvB5g"
+        },
+        "href": "https://api.spotify.com/v1/albums/6nneI0xOh7SR2zvzHcvB5g",
+        "id": "6nneI0xOh7SR2zvzHcvB5g",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f56d363d03630bf3ee50b705",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f56d363d03630bf3ee50b705",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f56d363d03630bf3ee50b705",
+            "width": 64
+          }
+        ],
+        "name": "Clara (the night is dark)",
+        "release_date": "2022-10-27",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:6nneI0xOh7SR2zvzHcvB5g"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 278400,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201036"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1PuxHPD8l3mm2CbxrMXy8N"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1PuxHPD8l3mm2CbxrMXy8N",
+      "id": "1PuxHPD8l3mm2CbxrMXy8N",
+      "is_local": false,
+      "name": "Clara (the night is dark)",
+      "popularity": 62,
+      "preview_url": "https://p.scdn.co/mp3-preview/e23dd172c6be452611ba3d7b803a0a3b768dc17a?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1PuxHPD8l3mm2CbxrMXy8N"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+            },
+            "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+            "id": "3OsRAKCvk37zwYcnzRf5XF",
+            "name": "Moby",
+            "type": "artist",
+            "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1xvxKcfieI9U1aEzOV8HCJ"
+        },
+        "href": "https://api.spotify.com/v1/albums/1xvxKcfieI9U1aEzOV8HCJ",
+        "id": "1xvxKcfieI9U1aEzOV8HCJ",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f2756789b4e46a2e1c01dbe5",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f2756789b4e46a2e1c01dbe5",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f2756789b4e46a2e1c01dbe5",
+            "width": 64
+          }
+        ],
+        "name": "Rescue Me",
+        "release_date": "2022-10-10",
+        "release_date_precision": "day",
+        "total_tracks": 6,
+        "type": "album",
+        "uri": "spotify:album:1xvxKcfieI9U1aEzOV8HCJ"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+          },
+          "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+          "id": "3OsRAKCvk37zwYcnzRf5XF",
+          "name": "Moby",
+          "type": "artist",
+          "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1vqfuBk5JF1LynFQZ19p3r"
+          },
+          "href": "https://api.spotify.com/v1/artists/1vqfuBk5JF1LynFQZ19p3r",
+          "id": "1vqfuBk5JF1LynFQZ19p3r",
+          "name": "Apollo Jane",
+          "type": "artist",
+          "uri": "spotify:artist:1vqfuBk5JF1LynFQZ19p3r"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 204055,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB3AD2210021"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/39QZxoXH9jfjmY8iwFyrNB"
+      },
+      "href": "https://api.spotify.com/v1/tracks/39QZxoXH9jfjmY8iwFyrNB",
+      "id": "39QZxoXH9jfjmY8iwFyrNB",
+      "is_local": false,
+      "name": "Rescue Me",
+      "popularity": 50,
+      "preview_url": "https://p.scdn.co/mp3-preview/2cb360bb14ba65af8f8e136a5dac1da6d3be9de6?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:39QZxoXH9jfjmY8iwFyrNB"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+            },
+            "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+            "id": "3OsRAKCvk37zwYcnzRf5XF",
+            "name": "Moby",
+            "type": "artist",
+            "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1xvxKcfieI9U1aEzOV8HCJ"
+        },
+        "href": "https://api.spotify.com/v1/albums/1xvxKcfieI9U1aEzOV8HCJ",
+        "id": "1xvxKcfieI9U1aEzOV8HCJ",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f2756789b4e46a2e1c01dbe5",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f2756789b4e46a2e1c01dbe5",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f2756789b4e46a2e1c01dbe5",
+            "width": 64
+          }
+        ],
+        "name": "Rescue Me",
+        "release_date": "2022-10-10",
+        "release_date_precision": "day",
+        "total_tracks": 6,
+        "type": "album",
+        "uri": "spotify:album:1xvxKcfieI9U1aEzOV8HCJ"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3OsRAKCvk37zwYcnzRf5XF"
+          },
+          "href": "https://api.spotify.com/v1/artists/3OsRAKCvk37zwYcnzRf5XF",
+          "id": "3OsRAKCvk37zwYcnzRf5XF",
+          "name": "Moby",
+          "type": "artist",
+          "uri": "spotify:artist:3OsRAKCvk37zwYcnzRf5XF"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1vqfuBk5JF1LynFQZ19p3r"
+          },
+          "href": "https://api.spotify.com/v1/artists/1vqfuBk5JF1LynFQZ19p3r",
+          "id": "1vqfuBk5JF1LynFQZ19p3r",
+          "name": "Apollo Jane",
+          "type": "artist",
+          "uri": "spotify:artist:1vqfuBk5JF1LynFQZ19p3r"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 329379,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB3AD2210022"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/29JgLJAM6wAX20rnfm5nD0"
+      },
+      "href": "https://api.spotify.com/v1/tracks/29JgLJAM6wAX20rnfm5nD0",
+      "id": "29JgLJAM6wAX20rnfm5nD0",
+      "is_local": false,
+      "name": "Rescue Me - Quiet Version",
+      "popularity": 35,
+      "preview_url": "https://p.scdn.co/mp3-preview/ec6155f35a39aefdf06f15b9d6952ff1b5acf570?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:29JgLJAM6wAX20rnfm5nD0"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1lmP325N7mFdhDOl7tMfpL"
+            },
+            "href": "https://api.spotify.com/v1/artists/1lmP325N7mFdhDOl7tMfpL",
+            "id": "1lmP325N7mFdhDOl7tMfpL",
+            "name": "Forma",
+            "type": "artist",
+            "uri": "spotify:artist:1lmP325N7mFdhDOl7tMfpL"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/71rqI5HtraA3qXBwatyG6e"
+            },
+            "href": "https://api.spotify.com/v1/artists/71rqI5HtraA3qXBwatyG6e",
+            "id": "71rqI5HtraA3qXBwatyG6e",
+            "name": "Innellea",
+            "type": "artist",
+            "uri": "spotify:artist:71rqI5HtraA3qXBwatyG6e"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2ldvU2vukDp8TyH9qDie2G"
+        },
+        "href": "https://api.spotify.com/v1/albums/2ldvU2vukDp8TyH9qDie2G",
+        "id": "2ldvU2vukDp8TyH9qDie2G",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273d578f963ed02a36d4f124880",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02d578f963ed02a36d4f124880",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851d578f963ed02a36d4f124880",
+            "width": 64
+          }
+        ],
+        "name": "In Control (Innellea Remix)",
+        "release_date": "2022-09-14",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:2ldvU2vukDp8TyH9qDie2G"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1lmP325N7mFdhDOl7tMfpL"
+          },
+          "href": "https://api.spotify.com/v1/artists/1lmP325N7mFdhDOl7tMfpL",
+          "id": "1lmP325N7mFdhDOl7tMfpL",
+          "name": "Forma",
+          "type": "artist",
+          "uri": "spotify:artist:1lmP325N7mFdhDOl7tMfpL"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/71rqI5HtraA3qXBwatyG6e"
+          },
+          "href": "https://api.spotify.com/v1/artists/71rqI5HtraA3qXBwatyG6e",
+          "id": "71rqI5HtraA3qXBwatyG6e",
+          "name": "Innellea",
+          "type": "artist",
+          "uri": "spotify:artist:71rqI5HtraA3qXBwatyG6e"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 345135,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205120"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/35fdRgZrz5ujDGBaqhoPE8"
+      },
+      "href": "https://api.spotify.com/v1/tracks/35fdRgZrz5ujDGBaqhoPE8",
+      "id": "35fdRgZrz5ujDGBaqhoPE8",
+      "is_local": false,
+      "name": "In Control - Innellea Remix",
+      "popularity": 57,
+      "preview_url": "https://p.scdn.co/mp3-preview/0399074035c758534a206cf87d20599f6be1b95e?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:35fdRgZrz5ujDGBaqhoPE8"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0vTVU0KH0CVzijsoKGsTPl"
+            },
+            "href": "https://api.spotify.com/v1/artists/0vTVU0KH0CVzijsoKGsTPl",
+            "id": "0vTVU0KH0CVzijsoKGsTPl",
+            "name": "Barry Can't Swim",
+            "type": "artist",
+            "uri": "spotify:artist:0vTVU0KH0CVzijsoKGsTPl"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3mkzFWYCYAGqxo02F1trQL"
+            },
+            "href": "https://api.spotify.com/v1/artists/3mkzFWYCYAGqxo02F1trQL",
+            "id": "3mkzFWYCYAGqxo02F1trQL",
+            "name": "Taite Imogen",
+            "type": "artist",
+            "uri": "spotify:artist:3mkzFWYCYAGqxo02F1trQL"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0URZfqUQlB4JreGiq1KiK9"
+        },
+        "href": "https://api.spotify.com/v1/albums/0URZfqUQlB4JreGiq1KiK9",
+        "id": "0URZfqUQlB4JreGiq1KiK9",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273c3a29135b4ffc2cd146447b8",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02c3a29135b4ffc2cd146447b8",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851c3a29135b4ffc2cd146447b8",
+            "width": 64
+          }
+        ],
+        "name": "God Is The Space Between Us",
+        "release_date": "2022-03-30",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:0URZfqUQlB4JreGiq1KiK9"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0vTVU0KH0CVzijsoKGsTPl"
+          },
+          "href": "https://api.spotify.com/v1/artists/0vTVU0KH0CVzijsoKGsTPl",
+          "id": "0vTVU0KH0CVzijsoKGsTPl",
+          "name": "Barry Can't Swim",
+          "type": "artist",
+          "uri": "spotify:artist:0vTVU0KH0CVzijsoKGsTPl"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3mkzFWYCYAGqxo02F1trQL"
+          },
+          "href": "https://api.spotify.com/v1/artists/3mkzFWYCYAGqxo02F1trQL",
+          "id": "3mkzFWYCYAGqxo02F1trQL",
+          "name": "Taite Imogen",
+          "type": "artist",
+          "uri": "spotify:artist:3mkzFWYCYAGqxo02F1trQL"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 187988,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBCFB2200129"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5I73WkfhuOvavHVYk3TGrm"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5I73WkfhuOvavHVYk3TGrm",
+      "id": "5I73WkfhuOvavHVYk3TGrm",
+      "is_local": false,
+      "name": "God Is The Space Between Us",
+      "popularity": 61,
+      "preview_url": "https://p.scdn.co/mp3-preview/8a9724078bbc3de0ccd76c2bc018ec3ca7a7c58d?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5I73WkfhuOvavHVYk3TGrm"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0QaSiI5TLA4N7mcsdxShDO"
+            },
+            "href": "https://api.spotify.com/v1/artists/0QaSiI5TLA4N7mcsdxShDO",
+            "id": "0QaSiI5TLA4N7mcsdxShDO",
+            "name": "Sub Focus",
+            "type": "artist",
+            "uri": "spotify:artist:0QaSiI5TLA4N7mcsdxShDO"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+            },
+            "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+            "id": "1QMgre3BHX161ZHtWMUu6S",
+            "name": "Dimension",
+            "type": "artist",
+            "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0Gt9NV2s7pSvP7g2F1nXGc"
+        },
+        "href": "https://api.spotify.com/v1/albums/0Gt9NV2s7pSvP7g2F1nXGc",
+        "id": "0Gt9NV2s7pSvP7g2F1nXGc",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273b496a5def7e67052028cde20",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02b496a5def7e67052028cde20",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851b496a5def7e67052028cde20",
+            "width": 64
+          }
+        ],
+        "name": "Ready To Fly",
+        "release_date": "2022-10-07",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:0Gt9NV2s7pSvP7g2F1nXGc"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0QaSiI5TLA4N7mcsdxShDO"
+          },
+          "href": "https://api.spotify.com/v1/artists/0QaSiI5TLA4N7mcsdxShDO",
+          "id": "0QaSiI5TLA4N7mcsdxShDO",
+          "name": "Sub Focus",
+          "type": "artist",
+          "uri": "spotify:artist:0QaSiI5TLA4N7mcsdxShDO"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+          },
+          "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+          "id": "1QMgre3BHX161ZHtWMUu6S",
+          "name": "Dimension",
+          "type": "artist",
+          "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 204500,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBUM72206309"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/0a2cA9H6KuOsoHLCnjl6YL"
+      },
+      "href": "https://api.spotify.com/v1/tracks/0a2cA9H6KuOsoHLCnjl6YL",
+      "id": "0a2cA9H6KuOsoHLCnjl6YL",
+      "is_local": false,
+      "name": "Ready To Fly",
+      "popularity": 66,
+      "preview_url": "https://p.scdn.co/mp3-preview/1613d8fed25c29bdcfa2681f74a2a29b2de9e43c?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:0a2cA9H6KuOsoHLCnjl6YL"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0pWwt5vGNzezEhfAcc420Y"
+            },
+            "href": "https://api.spotify.com/v1/artists/0pWwt5vGNzezEhfAcc420Y",
+            "id": "0pWwt5vGNzezEhfAcc420Y",
+            "name": "Mr.Kitty",
+            "type": "artist",
+            "uri": "spotify:artist:0pWwt5vGNzezEhfAcc420Y"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0yeP5olfo8IIu6UBGfUWHo"
+        },
+        "href": "https://api.spotify.com/v1/albums/0yeP5olfo8IIu6UBGfUWHo",
+        "id": "0yeP5olfo8IIu6UBGfUWHo",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2732c8acf6e66607fff1fd23841",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e022c8acf6e66607fff1fd23841",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048512c8acf6e66607fff1fd23841",
+            "width": 64
+          }
+        ],
+        "name": "Time",
+        "release_date": "2014-08-08",
+        "release_date_precision": "day",
+        "total_tracks": 15,
+        "type": "album",
+        "uri": "spotify:album:0yeP5olfo8IIu6UBGfUWHo"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0pWwt5vGNzezEhfAcc420Y"
+          },
+          "href": "https://api.spotify.com/v1/artists/0pWwt5vGNzezEhfAcc420Y",
+          "id": "0pWwt5vGNzezEhfAcc420Y",
+          "name": "Mr.Kitty",
+          "type": "artist",
+          "uri": "spotify:artist:0pWwt5vGNzezEhfAcc420Y"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 257147,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKPL1412568"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5FkJHVudUByVjanCqFXRql"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5FkJHVudUByVjanCqFXRql",
+      "id": "5FkJHVudUByVjanCqFXRql",
+      "is_local": false,
+      "name": "After Dark",
+      "popularity": 73,
+      "preview_url": "https://p.scdn.co/mp3-preview/59a86a705559f616bddbf476c7c60257872d68f2?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 9,
+      "type": "track",
+      "uri": "spotify:track:5FkJHVudUByVjanCqFXRql"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
+            },
+            "href": "https://api.spotify.com/v1/artists/3AA28KZvwAUcZuOKwyblJQ",
+            "id": "3AA28KZvwAUcZuOKwyblJQ",
+            "name": "Gorillaz",
+            "type": "artist",
+            "uri": "spotify:artist:3AA28KZvwAUcZuOKwyblJQ"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+            },
+            "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+            "id": "5INjqkS1o8h1imAzPqGZBb",
+            "name": "Tame Impala",
+            "type": "artist",
+            "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6GI3CJjT2bOnMfprCpjT1d"
+            },
+            "href": "https://api.spotify.com/v1/artists/6GI3CJjT2bOnMfprCpjT1d",
+            "id": "6GI3CJjT2bOnMfprCpjT1d",
+            "name": "Bootie Brown",
+            "type": "artist",
+            "uri": "spotify:artist:6GI3CJjT2bOnMfprCpjT1d"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4V9YFKLqZ5h8nQFTvDQscC"
+        },
+        "href": "https://api.spotify.com/v1/albums/4V9YFKLqZ5h8nQFTvDQscC",
+        "id": "4V9YFKLqZ5h8nQFTvDQscC",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273fda889bb57058a4a1b88edcd",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02fda889bb57058a4a1b88edcd",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851fda889bb57058a4a1b88edcd",
+            "width": 64
+          }
+        ],
+        "name": "New Gold (feat. Tame Impala and Bootie Brown)",
+        "release_date": "2022-08-31",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:4V9YFKLqZ5h8nQFTvDQscC"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
+          },
+          "href": "https://api.spotify.com/v1/artists/3AA28KZvwAUcZuOKwyblJQ",
+          "id": "3AA28KZvwAUcZuOKwyblJQ",
+          "name": "Gorillaz",
+          "type": "artist",
+          "uri": "spotify:artist:3AA28KZvwAUcZuOKwyblJQ"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+          },
+          "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+          "id": "5INjqkS1o8h1imAzPqGZBb",
+          "name": "Tame Impala",
+          "type": "artist",
+          "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6GI3CJjT2bOnMfprCpjT1d"
+          },
+          "href": "https://api.spotify.com/v1/artists/6GI3CJjT2bOnMfprCpjT1d",
+          "id": "6GI3CJjT2bOnMfprCpjT1d",
+          "name": "Bootie Brown",
+          "type": "artist",
+          "uri": "spotify:artist:6GI3CJjT2bOnMfprCpjT1d"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 215149,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBAYE2200462"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/64dLd6rVqDLtkXFYrEUHIU"
+      },
+      "href": "https://api.spotify.com/v1/tracks/64dLd6rVqDLtkXFYrEUHIU",
+      "id": "64dLd6rVqDLtkXFYrEUHIU",
+      "is_local": false,
+      "name": "New Gold (feat. Tame Impala and Bootie Brown)",
+      "popularity": 80,
+      "preview_url": "https://p.scdn.co/mp3-preview/2d4f3af6a427a293cd0a0542242cfe60cd1ff4d3?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:64dLd6rVqDLtkXFYrEUHIU"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/49GY4uPAwdlk5lSGtfKWYl"
+            },
+            "href": "https://api.spotify.com/v1/artists/49GY4uPAwdlk5lSGtfKWYl",
+            "id": "49GY4uPAwdlk5lSGtfKWYl",
+            "name": "MJ Cole",
+            "type": "artist",
+            "uri": "spotify:artist:49GY4uPAwdlk5lSGtfKWYl"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0yT3AhIS383pWxB8W9VV1r"
+        },
+        "href": "https://api.spotify.com/v1/albums/0yT3AhIS383pWxB8W9VV1r",
+        "id": "0yT3AhIS383pWxB8W9VV1r",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27316dea558effd9e469fb989cb",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0216dea558effd9e469fb989cb",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485116dea558effd9e469fb989cb",
+            "width": 64
+          }
+        ],
+        "name": "Waking Up",
+        "release_date": "2019-02-27",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:0yT3AhIS383pWxB8W9VV1r"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/49GY4uPAwdlk5lSGtfKWYl"
+          },
+          "href": "https://api.spotify.com/v1/artists/49GY4uPAwdlk5lSGtfKWYl",
+          "id": "49GY4uPAwdlk5lSGtfKWYl",
+          "name": "MJ Cole",
+          "type": "artist",
+          "uri": "spotify:artist:49GY4uPAwdlk5lSGtfKWYl"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 259204,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "US23A1501191"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7z6YhYLnLkLOw2qBhH5CTh"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7z6YhYLnLkLOw2qBhH5CTh",
+      "id": "7z6YhYLnLkLOw2qBhH5CTh",
+      "is_local": false,
+      "name": "Serotonin",
+      "popularity": 41,
+      "preview_url": "https://p.scdn.co/mp3-preview/cfd9b11398f926904997ac56a81dd7de19e6d9a1?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 3,
+      "type": "track",
+      "uri": "spotify:track:7z6YhYLnLkLOw2qBhH5CTh"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+            },
+            "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+            "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+            "name": "Netsky",
+            "type": "artist",
+            "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6Bi0LU2EWGrSRybRuYsScL"
+        },
+        "href": "https://api.spotify.com/v1/albums/6Bi0LU2EWGrSRybRuYsScL",
+        "id": "6Bi0LU2EWGrSRybRuYsScL",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27363f80eddab655fd5efb21d92",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0263f80eddab655fd5efb21d92",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485163f80eddab655fd5efb21d92",
+            "width": 64
+          }
+        ],
+        "name": "I Refuse / Midnight Express",
+        "release_date": "2010",
+        "release_date_precision": "year",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:6Bi0LU2EWGrSRybRuYsScL"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+          },
+          "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+          "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+          "name": "Netsky",
+          "type": "artist",
+          "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 355862,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBQZQ0901130"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1OBi4IRkuVOCegnDHG3xhj"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1OBi4IRkuVOCegnDHG3xhj",
+      "id": "1OBi4IRkuVOCegnDHG3xhj",
+      "is_local": false,
+      "name": "I Refuse",
+      "popularity": 41,
+      "preview_url": "https://p.scdn.co/mp3-preview/a5e7888f5e258224484910c23aa71227dc8c2945?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1OBi4IRkuVOCegnDHG3xhj"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6ZHeg2Op5ZkNppXbNLSglj"
+            },
+            "href": "https://api.spotify.com/v1/artists/6ZHeg2Op5ZkNppXbNLSglj",
+            "id": "6ZHeg2Op5ZkNppXbNLSglj",
+            "name": "Willaris. K",
+            "type": "artist",
+            "uri": "spotify:artist:6ZHeg2Op5ZkNppXbNLSglj"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/3pPn8xjYMTi303ZEs7tujA"
+        },
+        "href": "https://api.spotify.com/v1/albums/3pPn8xjYMTi303ZEs7tujA",
+        "id": "3pPn8xjYMTi303ZEs7tujA",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a2b602200e9758e7f6ae20bc",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a2b602200e9758e7f6ae20bc",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a2b602200e9758e7f6ae20bc",
+            "width": 64
+          }
+        ],
+        "name": "Double Demerits / Harsh",
+        "release_date": "2022-09-27",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:3pPn8xjYMTi303ZEs7tujA"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6ZHeg2Op5ZkNppXbNLSglj"
+          },
+          "href": "https://api.spotify.com/v1/artists/6ZHeg2Op5ZkNppXbNLSglj",
+          "id": "6ZHeg2Op5ZkNppXbNLSglj",
+          "name": "Willaris. K",
+          "type": "artist",
+          "uri": "spotify:artist:6ZHeg2Op5ZkNppXbNLSglj"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 298643,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USUG12206728"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7xP8b4AiHoT8gLYsZrdTem"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7xP8b4AiHoT8gLYsZrdTem",
+      "id": "7xP8b4AiHoT8gLYsZrdTem",
+      "is_local": false,
+      "name": "Double Demerits",
+      "popularity": 18,
+      "preview_url": "https://p.scdn.co/mp3-preview/584d26cfc723c8c3c0092ec616021ea250ef4469?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:7xP8b4AiHoT8gLYsZrdTem"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6xq7g0E52yq4y8Op9X82Uo"
+            },
+            "href": "https://api.spotify.com/v1/artists/6xq7g0E52yq4y8Op9X82Uo",
+            "id": "6xq7g0E52yq4y8Op9X82Uo",
+            "name": "TIBASKO",
+            "type": "artist",
+            "uri": "spotify:artist:6xq7g0E52yq4y8Op9X82Uo"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4mxQ6vTBvss4je3abdHWp8"
+        },
+        "href": "https://api.spotify.com/v1/albums/4mxQ6vTBvss4je3abdHWp8",
+        "id": "4mxQ6vTBvss4je3abdHWp8",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273bf597affee18cf1ceeecadc2",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02bf597affee18cf1ceeecadc2",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851bf597affee18cf1ceeecadc2",
+            "width": 64
+          }
+        ],
+        "name": "Still Rushing / System Error",
+        "release_date": "2022-07-29",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:4mxQ6vTBvss4je3abdHWp8"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6xq7g0E52yq4y8Op9X82Uo"
+          },
+          "href": "https://api.spotify.com/v1/artists/6xq7g0E52yq4y8Op9X82Uo",
+          "id": "6xq7g0E52yq4y8Op9X82Uo",
+          "name": "TIBASKO",
+          "type": "artist",
+          "uri": "spotify:artist:6xq7g0E52yq4y8Op9X82Uo"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 226173,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKQU2258572"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/18SaC9Z58nrfjkWbSZUjG3"
+      },
+      "href": "https://api.spotify.com/v1/tracks/18SaC9Z58nrfjkWbSZUjG3",
+      "id": "18SaC9Z58nrfjkWbSZUjG3",
+      "is_local": false,
+      "name": "Still Rushing",
+      "popularity": 34,
+      "preview_url": "https://p.scdn.co/mp3-preview/8c2040f0da2ad3080a31eb33362807f0bc8a686e?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:18SaC9Z58nrfjkWbSZUjG3"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+            },
+            "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+            "id": "2CIMQHirSU0MQqyYHq0eOx",
+            "name": "deadmau5",
+            "type": "artist",
+            "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+            },
+            "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+            "id": "1QMgre3BHX161ZHtWMUu6S",
+            "name": "Dimension",
+            "type": "artist",
+            "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/1C3Agf6jqcHNRSeSneAoMg"
+        },
+        "href": "https://api.spotify.com/v1/albums/1C3Agf6jqcHNRSeSneAoMg",
+        "id": "1C3Agf6jqcHNRSeSneAoMg",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2731e60c7f2cbd8d3026c50a7c3",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e021e60c7f2cbd8d3026c50a7c3",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048511e60c7f2cbd8d3026c50a7c3",
+            "width": 64
+          }
+        ],
+        "name": "Strobe (Dimension Remix)",
+        "release_date": "2016-09-22",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:1C3Agf6jqcHNRSeSneAoMg"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2CIMQHirSU0MQqyYHq0eOx"
+          },
+          "href": "https://api.spotify.com/v1/artists/2CIMQHirSU0MQqyYHq0eOx",
+          "id": "2CIMQHirSU0MQqyYHq0eOx",
+          "name": "deadmau5",
+          "type": "artist",
+          "uri": "spotify:artist:2CIMQHirSU0MQqyYHq0eOx"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1QMgre3BHX161ZHtWMUu6S"
+          },
+          "href": "https://api.spotify.com/v1/artists/1QMgre3BHX161ZHtWMUu6S",
+          "id": "1QMgre3BHX161ZHtWMUu6S",
+          "name": "Dimension",
+          "type": "artist",
+          "uri": "spotify:artist:1QMgre3BHX161ZHtWMUu6S"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 508965,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBTDG1301165"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/34kjfTbXaqCHIaKatdNYVd"
+      },
+      "href": "https://api.spotify.com/v1/tracks/34kjfTbXaqCHIaKatdNYVd",
+      "id": "34kjfTbXaqCHIaKatdNYVd",
+      "is_local": false,
+      "name": "Strobe - Dimension Remix",
+      "popularity": 24,
+      "preview_url": "https://p.scdn.co/mp3-preview/8dd93dfa721e52531e91e9002501ec08dc4e0405?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:34kjfTbXaqCHIaKatdNYVd"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0bGDTQ78MVgI5Snqo9KJZw"
+            },
+            "href": "https://api.spotify.com/v1/artists/0bGDTQ78MVgI5Snqo9KJZw",
+            "id": "0bGDTQ78MVgI5Snqo9KJZw",
+            "name": "Qrion",
+            "type": "artist",
+            "uri": "spotify:artist:0bGDTQ78MVgI5Snqo9KJZw"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0xyI5ztV0OXUVgZHxLUkzH"
+        },
+        "href": "https://api.spotify.com/v1/albums/0xyI5ztV0OXUVgZHxLUkzH",
+        "id": "0xyI5ztV0OXUVgZHxLUkzH",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273526c200e6064faa615b771ed",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02526c200e6064faa615b771ed",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851526c200e6064faa615b771ed",
+            "width": 64
+          }
+        ],
+        "name": "Proud",
+        "release_date": "2021-10-12",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:0xyI5ztV0OXUVgZHxLUkzH"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0bGDTQ78MVgI5Snqo9KJZw"
+          },
+          "href": "https://api.spotify.com/v1/artists/0bGDTQ78MVgI5Snqo9KJZw",
+          "id": "0bGDTQ78MVgI5Snqo9KJZw",
+          "name": "Qrion",
+          "type": "artist",
+          "uri": "spotify:artist:0bGDTQ78MVgI5Snqo9KJZw"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 236101,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2104531"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/57fgc1wsUpAj0BfTHncOaT"
+      },
+      "href": "https://api.spotify.com/v1/tracks/57fgc1wsUpAj0BfTHncOaT",
+      "id": "57fgc1wsUpAj0BfTHncOaT",
+      "is_local": false,
+      "name": "Proud",
+      "popularity": 33,
+      "preview_url": "https://p.scdn.co/mp3-preview/949e7ce92109713256c0be00633b712fde3bca2e?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:57fgc1wsUpAj0BfTHncOaT"
+    },
+    {
+      "album": {
+        "album_type": "COMPILATION",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/10gzBoINW3cLJfZUka8Zoe"
+            },
+            "href": "https://api.spotify.com/v1/artists/10gzBoINW3cLJfZUka8Zoe",
+            "id": "10gzBoINW3cLJfZUka8Zoe",
+            "name": "Above & Beyond",
+            "type": "artist",
+            "uri": "spotify:artist:10gzBoINW3cLJfZUka8Zoe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/3SppKnyNf5sdqLxCMwsTzX"
+        },
+        "href": "https://api.spotify.com/v1/albums/3SppKnyNf5sdqLxCMwsTzX",
+        "id": "3SppKnyNf5sdqLxCMwsTzX",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273e7edcaad955451771f08ff3b",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02e7edcaad955451771f08ff3b",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851e7edcaad955451771f08ff3b",
+            "width": 64
+          }
+        ],
+        "name": "Anjunabeats Volume 14",
+        "release_date": "2019-05-31",
+        "release_date_precision": "day",
+        "total_tracks": 39,
+        "type": "album",
+        "uri": "spotify:album:3SppKnyNf5sdqLxCMwsTzX"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6TwTAUcCILwoSPY2N3etuY"
+          },
+          "href": "https://api.spotify.com/v1/artists/6TwTAUcCILwoSPY2N3etuY",
+          "id": "6TwTAUcCILwoSPY2N3etuY",
+          "name": "Reflekt",
+          "type": "artist",
+          "uri": "spotify:artist:6TwTAUcCILwoSPY2N3etuY"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4mYOtUmFApJtEbaeGt0RCk"
+          },
+          "href": "https://api.spotify.com/v1/artists/4mYOtUmFApJtEbaeGt0RCk",
+          "id": "4mYOtUmFApJtEbaeGt0RCk",
+          "name": "delline bass",
+          "type": "artist",
+          "uri": "spotify:artist:4mYOtUmFApJtEbaeGt0RCk"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5EmEZjq8eHEC6qFnT63Lza"
+          },
+          "href": "https://api.spotify.com/v1/artists/5EmEZjq8eHEC6qFnT63Lza",
+          "id": "5EmEZjq8eHEC6qFnT63Lza",
+          "name": "Tinlicker",
+          "type": "artist",
+          "uri": "spotify:artist:5EmEZjq8eHEC6qFnT63Lza"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 308053,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA1900917"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5bHbUMtuZIpHtTPdoJmcaN"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5bHbUMtuZIpHtTPdoJmcaN",
+      "id": "5bHbUMtuZIpHtTPdoJmcaN",
+      "is_local": false,
+      "name": "Need To Feel Loved - Tinlicker Remix",
+      "popularity": 51,
+      "preview_url": "https://p.scdn.co/mp3-preview/7d62f1501998c3109c05309e3e846e2c8290bfe8?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 8,
+      "type": "track",
+      "uri": "spotify:track:5bHbUMtuZIpHtTPdoJmcaN"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0SFtIrRytNI4kcf93Tbhdf"
+        },
+        "href": "https://api.spotify.com/v1/albums/0SFtIrRytNI4kcf93Tbhdf",
+        "id": "0SFtIrRytNI4kcf93Tbhdf",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a871bc3a84418ad1240a5d4e",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a871bc3a84418ad1240a5d4e",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a871bc3a84418ad1240a5d4e",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 2 (February 2 - October 15 2021)",
+        "release_date": "2021-11-19",
+        "release_date_precision": "day",
+        "total_tracks": 16,
+        "type": "album",
+        "uri": "spotify:album:0SFtIrRytNI4kcf93Tbhdf"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 121708,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2101341"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/03LSUjL0Rqh2Lpj1rKgsmG"
+      },
+      "href": "https://api.spotify.com/v1/tracks/03LSUjL0Rqh2Lpj1rKgsmG",
+      "id": "03LSUjL0Rqh2Lpj1rKgsmG",
+      "is_local": false,
+      "name": "Carlos (interlude)",
+      "popularity": 43,
+      "preview_url": "https://p.scdn.co/mp3-preview/d0d3636d957baad12fe2e58f759607d2d922236b?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 8,
+      "type": "track",
+      "uri": "spotify:track:03LSUjL0Rqh2Lpj1rKgsmG"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4cxzGdmQtUZJL1WYOdFQ5F"
+            },
+            "href": "https://api.spotify.com/v1/artists/4cxzGdmQtUZJL1WYOdFQ5F",
+            "id": "4cxzGdmQtUZJL1WYOdFQ5F",
+            "name": "Kove",
+            "type": "artist",
+            "uri": "spotify:artist:4cxzGdmQtUZJL1WYOdFQ5F"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6MfYv3Zkj5zwMNbUfbAifz"
+            },
+            "href": "https://api.spotify.com/v1/artists/6MfYv3Zkj5zwMNbUfbAifz",
+            "id": "6MfYv3Zkj5zwMNbUfbAifz",
+            "name": "Ben Duffy",
+            "type": "artist",
+            "uri": "spotify:artist:6MfYv3Zkj5zwMNbUfbAifz"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2nlfwe48o2mE0Jam3uN88C"
+        },
+        "href": "https://api.spotify.com/v1/albums/2nlfwe48o2mE0Jam3uN88C",
+        "id": "2nlfwe48o2mE0Jam3uN88C",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27343e421b48df3b4a09ce3c722",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0243e421b48df3b4a09ce3c722",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485143e421b48df3b4a09ce3c722",
+            "width": 64
+          }
+        ],
+        "name": "Echoes",
+        "release_date": "2019-03-29",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:2nlfwe48o2mE0Jam3uN88C"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4cxzGdmQtUZJL1WYOdFQ5F"
+          },
+          "href": "https://api.spotify.com/v1/artists/4cxzGdmQtUZJL1WYOdFQ5F",
+          "id": "4cxzGdmQtUZJL1WYOdFQ5F",
+          "name": "Kove",
+          "type": "artist",
+          "uri": "spotify:artist:4cxzGdmQtUZJL1WYOdFQ5F"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6MfYv3Zkj5zwMNbUfbAifz"
+          },
+          "href": "https://api.spotify.com/v1/artists/6MfYv3Zkj5zwMNbUfbAifz",
+          "id": "6MfYv3Zkj5zwMNbUfbAifz",
+          "name": "Ben Duffy",
+          "type": "artist",
+          "uri": "spotify:artist:6MfYv3Zkj5zwMNbUfbAifz"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 194482,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB2LD1900072"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2vS2LgcY2FclC21sJ4ukJm"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2vS2LgcY2FclC21sJ4ukJm",
+      "id": "2vS2LgcY2FclC21sJ4ukJm",
+      "is_local": false,
+      "name": "Echoes",
+      "popularity": 53,
+      "preview_url": "https://p.scdn.co/mp3-preview/292f4108ec0cb7c7bc35a95e7e9f66247bf81e06?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:2vS2LgcY2FclC21sJ4ukJm"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/532SqCIYmJyXEdEiCJLgYG"
+            },
+            "href": "https://api.spotify.com/v1/artists/532SqCIYmJyXEdEiCJLgYG",
+            "id": "532SqCIYmJyXEdEiCJLgYG",
+            "name": "Cristoph",
+            "type": "artist",
+            "uri": "spotify:artist:532SqCIYmJyXEdEiCJLgYG"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+            "id": "3IG3Ub4ra8AuSxCFDVkVco",
+            "name": "Franky Wah",
+            "type": "artist",
+            "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/75urDDpUkt0jMdQgVx3XFV"
+            },
+            "href": "https://api.spotify.com/v1/artists/75urDDpUkt0jMdQgVx3XFV",
+            "id": "75urDDpUkt0jMdQgVx3XFV",
+            "name": "Artche",
+            "type": "artist",
+            "uri": "spotify:artist:75urDDpUkt0jMdQgVx3XFV"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0V9gdn8ZnhvkpRAvdnkT7I"
+        },
+        "href": "https://api.spotify.com/v1/albums/0V9gdn8ZnhvkpRAvdnkT7I",
+        "id": "0V9gdn8ZnhvkpRAvdnkT7I",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273c549572dee0d38630951ee83",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02c549572dee0d38630951ee83",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851c549572dee0d38630951ee83",
+            "width": 64
+          }
+        ],
+        "name": "The World You See",
+        "release_date": "2021-02-26",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:0V9gdn8ZnhvkpRAvdnkT7I"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/532SqCIYmJyXEdEiCJLgYG"
+          },
+          "href": "https://api.spotify.com/v1/artists/532SqCIYmJyXEdEiCJLgYG",
+          "id": "532SqCIYmJyXEdEiCJLgYG",
+          "name": "Cristoph",
+          "type": "artist",
+          "uri": "spotify:artist:532SqCIYmJyXEdEiCJLgYG"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+          "id": "3IG3Ub4ra8AuSxCFDVkVco",
+          "name": "Franky Wah",
+          "type": "artist",
+          "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/75urDDpUkt0jMdQgVx3XFV"
+          },
+          "href": "https://api.spotify.com/v1/artists/75urDDpUkt0jMdQgVx3XFV",
+          "id": "75urDDpUkt0jMdQgVx3XFV",
+          "name": "Artche",
+          "type": "artist",
+          "uri": "spotify:artist:75urDDpUkt0jMdQgVx3XFV"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 217515,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB6CM2100173"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/4TQgbkv9CF1Qy4GIfpZeSO"
+      },
+      "href": "https://api.spotify.com/v1/tracks/4TQgbkv9CF1Qy4GIfpZeSO",
+      "id": "4TQgbkv9CF1Qy4GIfpZeSO",
+      "is_local": false,
+      "name": "The World You See",
+      "popularity": 50,
+      "preview_url": "https://p.scdn.co/mp3-preview/5ab4a2d1d5e74f4932d757e1929df57313f489bd?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:4TQgbkv9CF1Qy4GIfpZeSO"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6u4jLGLPuarS3i2XWHVxoS"
+            },
+            "href": "https://api.spotify.com/v1/artists/6u4jLGLPuarS3i2XWHVxoS",
+            "id": "6u4jLGLPuarS3i2XWHVxoS",
+            "name": "Sasha",
+            "type": "artist",
+            "uri": "spotify:artist:6u4jLGLPuarS3i2XWHVxoS"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+            "id": "3IG3Ub4ra8AuSxCFDVkVco",
+            "name": "Franky Wah",
+            "type": "artist",
+            "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/7jGjzC6P9754JS5UVKWifW"
+        },
+        "href": "https://api.spotify.com/v1/albums/7jGjzC6P9754JS5UVKWifW",
+        "id": "7jGjzC6P9754JS5UVKWifW",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2739c1fbc8be7e570f16309d28f",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e029c1fbc8be7e570f16309d28f",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048519c1fbc8be7e570f16309d28f",
+            "width": 64
+          }
+        ],
+        "name": "Haunted",
+        "release_date": "2020-12-18",
+        "release_date_precision": "day",
+        "total_tracks": 5,
+        "type": "album",
+        "uri": "spotify:album:7jGjzC6P9754JS5UVKWifW"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6u4jLGLPuarS3i2XWHVxoS"
+          },
+          "href": "https://api.spotify.com/v1/artists/6u4jLGLPuarS3i2XWHVxoS",
+          "id": "6u4jLGLPuarS3i2XWHVxoS",
+          "name": "Sasha",
+          "type": "artist",
+          "uri": "spotify:artist:6u4jLGLPuarS3i2XWHVxoS"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+          "id": "3IG3Ub4ra8AuSxCFDVkVco",
+          "name": "Franky Wah",
+          "type": "artist",
+          "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 256821,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "FRIDO2012419"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/6cm0CsFVU8QTLTVegPgHDm"
+      },
+      "href": "https://api.spotify.com/v1/tracks/6cm0CsFVU8QTLTVegPgHDm",
+      "id": "6cm0CsFVU8QTLTVegPgHDm",
+      "is_local": false,
+      "name": "Haunted",
+      "popularity": 35,
+      "preview_url": "https://p.scdn.co/mp3-preview/060e96323fcb0ba6d268e565d81aabb88f35e9f8?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:6cm0CsFVU8QTLTVegPgHDm"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+            },
+            "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+            "id": "0g3NiCRhEv7M4SEDMrpItN",
+            "name": "Totally Enormous Extinct Dinosaurs",
+            "type": "artist",
+            "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2VNsib3BSnjcR4Me2bW4iJ"
+        },
+        "href": "https://api.spotify.com/v1/albums/2VNsib3BSnjcR4Me2bW4iJ",
+        "id": "2VNsib3BSnjcR4Me2bW4iJ",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27394b507dbd18300a1cd94b7ff",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0294b507dbd18300a1cd94b7ff",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485194b507dbd18300a1cd94b7ff",
+            "width": 64
+          }
+        ],
+        "name": "Energy Fantasy (Remixes)",
+        "release_date": "2019-03-08",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:2VNsib3BSnjcR4Me2bW4iJ"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+          },
+          "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+          "id": "0g3NiCRhEv7M4SEDMrpItN",
+          "name": "Totally Enormous Extinct Dinosaurs",
+          "type": "artist",
+          "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2tEyBfwGBfQgLXeAJW0MgC"
+          },
+          "href": "https://api.spotify.com/v1/artists/2tEyBfwGBfQgLXeAJW0MgC",
+          "id": "2tEyBfwGBfQgLXeAJW0MgC",
+          "name": "Baltra",
+          "type": "artist",
+          "uri": "spotify:artist:2tEyBfwGBfQgLXeAJW0MgC"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 356080,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKPL1938581"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1rlmQKaW9Hp50cilO0zVZv"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1rlmQKaW9Hp50cilO0zVZv",
+      "id": "1rlmQKaW9Hp50cilO0zVZv",
+      "is_local": false,
+      "name": "Energy Fantasy - Baltra \"Vocal\" Remix",
+      "popularity": 11,
+      "preview_url": "https://p.scdn.co/mp3-preview/45fc159ee2b7a5486948457dfada0e20ead9e4ef?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:1rlmQKaW9Hp50cilO0zVZv"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+            },
+            "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+            "id": "3IG3Ub4ra8AuSxCFDVkVco",
+            "name": "Franky Wah",
+            "type": "artist",
+            "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2NkaRLi1emHFYLRT2JqxbL"
+        },
+        "href": "https://api.spotify.com/v1/albums/2NkaRLi1emHFYLRT2JqxbL",
+        "id": "2NkaRLi1emHFYLRT2JqxbL",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273e81a614dbcec768ce0bfaa2c",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02e81a614dbcec768ce0bfaa2c",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851e81a614dbcec768ce0bfaa2c",
+            "width": 64
+          }
+        ],
+        "name": "The Revival, Vol. 1",
+        "release_date": "2020-05-29",
+        "release_date_precision": "day",
+        "total_tracks": 14,
+        "type": "album",
+        "uri": "spotify:album:2NkaRLi1emHFYLRT2JqxbL"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3IG3Ub4ra8AuSxCFDVkVco"
+          },
+          "href": "https://api.spotify.com/v1/artists/3IG3Ub4ra8AuSxCFDVkVco",
+          "id": "3IG3Ub4ra8AuSxCFDVkVco",
+          "name": "Franky Wah",
+          "type": "artist",
+          "uri": "spotify:artist:3IG3Ub4ra8AuSxCFDVkVco"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 325039,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBCEN2000021"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/23hbF7NYTvwYk4TICcu3ZR"
+      },
+      "href": "https://api.spotify.com/v1/tracks/23hbF7NYTvwYk4TICcu3ZR",
+      "id": "23hbF7NYTvwYk4TICcu3ZR",
+      "is_local": false,
+      "name": "Cry No More",
+      "popularity": 29,
+      "preview_url": "https://p.scdn.co/mp3-preview/2ae3119a628647df30dd9dc2dc22c4f68f49b64a?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 12,
+      "type": "track",
+      "uri": "spotify:track:23hbF7NYTvwYk4TICcu3ZR"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4lCsf6uYTVnWSKm99eKkdY"
+            },
+            "href": "https://api.spotify.com/v1/artists/4lCsf6uYTVnWSKm99eKkdY",
+            "id": "4lCsf6uYTVnWSKm99eKkdY",
+            "name": "Seekae",
+            "type": "artist",
+            "uri": "spotify:artist:4lCsf6uYTVnWSKm99eKkdY"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6ViDQATM3uoaXqjBS2h7pO"
+        },
+        "href": "https://api.spotify.com/v1/albums/6ViDQATM3uoaXqjBS2h7pO",
+        "id": "6ViDQATM3uoaXqjBS2h7pO",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a0084d69f43f8dc944e930b7",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a0084d69f43f8dc944e930b7",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a0084d69f43f8dc944e930b7",
+            "width": 64
+          }
+        ],
+        "name": "Test & Recognise (Remixes)",
+        "release_date": "2014-08-14",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:6ViDQATM3uoaXqjBS2h7pO"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4lCsf6uYTVnWSKm99eKkdY"
+          },
+          "href": "https://api.spotify.com/v1/artists/4lCsf6uYTVnWSKm99eKkdY",
+          "id": "4lCsf6uYTVnWSKm99eKkdY",
+          "name": "Seekae",
+          "type": "artist",
+          "uri": "spotify:artist:4lCsf6uYTVnWSKm99eKkdY"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6nxWCVXbOlEVRexSbLsTer"
+          },
+          "href": "https://api.spotify.com/v1/artists/6nxWCVXbOlEVRexSbLsTer",
+          "id": "6nxWCVXbOlEVRexSbLsTer",
+          "name": "Flume",
+          "type": "artist",
+          "uri": "spotify:artist:6nxWCVXbOlEVRexSbLsTer"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 303660,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "AUFF01400535"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/24BYTj1tb5ovZcnIbtdTYD"
+      },
+      "href": "https://api.spotify.com/v1/tracks/24BYTj1tb5ovZcnIbtdTYD",
+      "id": "24BYTj1tb5ovZcnIbtdTYD",
+      "is_local": false,
+      "name": "Test & Recognise - Flume Re-work",
+      "popularity": 69,
+      "preview_url": "https://p.scdn.co/mp3-preview/d1c2c20b39cd8f9c37d277ae7c97b3989b718603?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:24BYTj1tb5ovZcnIbtdTYD"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1gMMbPTZtOb9W3IBYl6twO"
+            },
+            "href": "https://api.spotify.com/v1/artists/1gMMbPTZtOb9W3IBYl6twO",
+            "id": "1gMMbPTZtOb9W3IBYl6twO",
+            "name": "OLAN",
+            "type": "artist",
+            "uri": "spotify:artist:1gMMbPTZtOb9W3IBYl6twO"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4tSNagHpiYip5XqF3SZzAa"
+        },
+        "href": "https://api.spotify.com/v1/albums/4tSNagHpiYip5XqF3SZzAa",
+        "id": "4tSNagHpiYip5XqF3SZzAa",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2738c9cf43edc1a04a24e9e0df0",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e028c9cf43edc1a04a24e9e0df0",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048518c9cf43edc1a04a24e9e0df0",
+            "width": 64
+          }
+        ],
+        "name": "Promise To Keep",
+        "release_date": "2022-04-28",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:4tSNagHpiYip5XqF3SZzAa"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1gMMbPTZtOb9W3IBYl6twO"
+          },
+          "href": "https://api.spotify.com/v1/artists/1gMMbPTZtOb9W3IBYl6twO",
+          "id": "1gMMbPTZtOb9W3IBYl6twO",
+          "name": "OLAN",
+          "type": "artist",
+          "uri": "spotify:artist:1gMMbPTZtOb9W3IBYl6twO"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 288357,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2202044"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/3J8CjJWVaDbM9oE2XDyncj"
+      },
+      "href": "https://api.spotify.com/v1/tracks/3J8CjJWVaDbM9oE2XDyncj",
+      "id": "3J8CjJWVaDbM9oE2XDyncj",
+      "is_local": false,
+      "name": "Promise To Keep",
+      "popularity": 22,
+      "preview_url": "https://p.scdn.co/mp3-preview/61154c71031a178e8b7cdbd39eb01829549fc502?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:3J8CjJWVaDbM9oE2XDyncj"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+            },
+            "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+            "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+            "name": "Netsky",
+            "type": "artist",
+            "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/5RpkF55XZzzpWO0CnqcWw8"
+        },
+        "href": "https://api.spotify.com/v1/albums/5RpkF55XZzzpWO0CnqcWw8",
+        "id": "5RpkF55XZzzpWO0CnqcWw8",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273dcd9ab0c53e56eef188ea988",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02dcd9ab0c53e56eef188ea988",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851dcd9ab0c53e56eef188ea988",
+            "width": 64
+          }
+        ],
+        "name": "3",
+        "release_date": "2016-06-10",
+        "release_date_precision": "day",
+        "total_tracks": 12,
+        "type": "album",
+        "uri": "spotify:album:5RpkF55XZzzpWO0CnqcWw8"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5TgQ66WuWkoQ2xYxaSTnVP"
+          },
+          "href": "https://api.spotify.com/v1/artists/5TgQ66WuWkoQ2xYxaSTnVP",
+          "id": "5TgQ66WuWkoQ2xYxaSTnVP",
+          "name": "Netsky",
+          "type": "artist",
+          "uri": "spotify:artist:5TgQ66WuWkoQ2xYxaSTnVP"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3SvHrDiy9c35DFVnUysqkE"
+          },
+          "href": "https://api.spotify.com/v1/artists/3SvHrDiy9c35DFVnUysqkE",
+          "id": "3SvHrDiy9c35DFVnUysqkE",
+          "name": "Lowell",
+          "type": "artist",
+          "uri": "spotify:artist:3SvHrDiy9c35DFVnUysqkE"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 216960,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBARL1600152"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/518YAzM4k20EnkDvpJX1n8"
+      },
+      "href": "https://api.spotify.com/v1/tracks/518YAzM4k20EnkDvpJX1n8",
+      "id": "518YAzM4k20EnkDvpJX1n8",
+      "is_local": false,
+      "name": "Forget What You Look Like (feat. Lowell)",
+      "popularity": 37,
+      "preview_url": "https://p.scdn.co/mp3-preview/82791f64268fbc31dc17c1e57d5f5866039436c0?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 10,
+      "type": "track",
+      "uri": "spotify:track:518YAzM4k20EnkDvpJX1n8"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3XHO7cRUPCLOr6jwp8vsx5"
+            },
+            "href": "https://api.spotify.com/v1/artists/3XHO7cRUPCLOr6jwp8vsx5",
+            "id": "3XHO7cRUPCLOr6jwp8vsx5",
+            "name": "alt-J",
+            "type": "artist",
+            "uri": "spotify:artist:3XHO7cRUPCLOr6jwp8vsx5"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/39WJofoGKsqCZXKgORs1IP"
+        },
+        "href": "https://api.spotify.com/v1/albums/39WJofoGKsqCZXKgORs1IP",
+        "id": "39WJofoGKsqCZXKgORs1IP",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2734527d5b2468d0eed49d5326a",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e024527d5b2468d0eed49d5326a",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048514527d5b2468d0eed49d5326a",
+            "width": 64
+          }
+        ],
+        "name": "Deadcrush (Salute Remix)",
+        "release_date": "2017-08-30",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:39WJofoGKsqCZXKgORs1IP"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3XHO7cRUPCLOr6jwp8vsx5"
+          },
+          "href": "https://api.spotify.com/v1/artists/3XHO7cRUPCLOr6jwp8vsx5",
+          "id": "3XHO7cRUPCLOr6jwp8vsx5",
+          "name": "alt-J",
+          "type": "artist",
+          "uri": "spotify:artist:3XHO7cRUPCLOr6jwp8vsx5"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1np8xozf7ATJZDi9JX8Dx5"
+          },
+          "href": "https://api.spotify.com/v1/artists/1np8xozf7ATJZDi9JX8Dx5",
+          "id": "1np8xozf7ATJZDi9JX8Dx5",
+          "name": "salute",
+          "type": "artist",
+          "uri": "spotify:artist:1np8xozf7ATJZDi9JX8Dx5"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 258545,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GB5KW1702661"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5KALNRc9mIMNPwHURxzJNw"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5KALNRc9mIMNPwHURxzJNw",
+      "id": "5KALNRc9mIMNPwHURxzJNw",
+      "is_local": false,
+      "name": "Deadcrush - Salute Remix",
+      "popularity": 29,
+      "preview_url": "https://p.scdn.co/mp3-preview/8f420987f57119a1331485163073e4ca11da0fb4?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5KALNRc9mIMNPwHURxzJNw"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6Ip8FS7vWT1uKkJSweANQK"
+            },
+            "href": "https://api.spotify.com/v1/artists/6Ip8FS7vWT1uKkJSweANQK",
+            "id": "6Ip8FS7vWT1uKkJSweANQK",
+            "name": "Dave",
+            "type": "artist",
+            "uri": "spotify:artist:6Ip8FS7vWT1uKkJSweANQK"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/4GrFuXwRmEBJec22p58fsD"
+        },
+        "href": "https://api.spotify.com/v1/albums/4GrFuXwRmEBJec22p58fsD",
+        "id": "4GrFuXwRmEBJec22p58fsD",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273c1c8d2889455db6d03d309ed",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02c1c8d2889455db6d03d309ed",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851c1c8d2889455db6d03d309ed",
+            "width": 64
+          }
+        ],
+        "name": "PSYCHODRAMA",
+        "release_date": "2019-03-08",
+        "release_date_precision": "day",
+        "total_tracks": 11,
+        "type": "album",
+        "uri": "spotify:album:4GrFuXwRmEBJec22p58fsD"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6Ip8FS7vWT1uKkJSweANQK"
+          },
+          "href": "https://api.spotify.com/v1/artists/6Ip8FS7vWT1uKkJSweANQK",
+          "id": "6Ip8FS7vWT1uKkJSweANQK",
+          "name": "Dave",
+          "type": "artist",
+          "uri": "spotify:artist:6Ip8FS7vWT1uKkJSweANQK"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 202733,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBUM71900582"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7l1P6WtVtq1zQMq6qazNA4"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7l1P6WtVtq1zQMq6qazNA4",
+      "id": "7l1P6WtVtq1zQMq6qazNA4",
+      "is_local": false,
+      "name": "Environment",
+      "popularity": 59,
+      "preview_url": "https://p.scdn.co/mp3-preview/a95ce2335916f991d36d7239e91fd83d963586b1?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 8,
+      "type": "track",
+      "uri": "spotify:track:7l1P6WtVtq1zQMq6qazNA4"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/27gtK7m9vYwCyJ04zz0kIb"
+            },
+            "href": "https://api.spotify.com/v1/artists/27gtK7m9vYwCyJ04zz0kIb",
+            "id": "27gtK7m9vYwCyJ04zz0kIb",
+            "name": "Lane 8",
+            "type": "artist",
+            "uri": "spotify:artist:27gtK7m9vYwCyJ04zz0kIb"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+            },
+            "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+            "id": "0g3NiCRhEv7M4SEDMrpItN",
+            "name": "Totally Enormous Extinct Dinosaurs",
+            "type": "artist",
+            "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/08fGtbr8PDy84u2KRrNuXS"
+        },
+        "href": "https://api.spotify.com/v1/albums/08fGtbr8PDy84u2KRrNuXS",
+        "id": "08fGtbr8PDy84u2KRrNuXS",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2731b05da207113150ccc039661",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e021b05da207113150ccc039661",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048511b05da207113150ccc039661",
+            "width": 64
+          }
+        ],
+        "name": "Reviver (Totally Enormous Extinct Dinosaurs Remix)",
+        "release_date": "2022-10-13",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:08fGtbr8PDy84u2KRrNuXS"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/27gtK7m9vYwCyJ04zz0kIb"
+          },
+          "href": "https://api.spotify.com/v1/artists/27gtK7m9vYwCyJ04zz0kIb",
+          "id": "27gtK7m9vYwCyJ04zz0kIb",
+          "name": "Lane 8",
+          "type": "artist",
+          "uri": "spotify:artist:27gtK7m9vYwCyJ04zz0kIb"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0g3NiCRhEv7M4SEDMrpItN"
+          },
+          "href": "https://api.spotify.com/v1/artists/0g3NiCRhEv7M4SEDMrpItN",
+          "id": "0g3NiCRhEv7M4SEDMrpItN",
+          "name": "Totally Enormous Extinct Dinosaurs",
+          "type": "artist",
+          "uri": "spotify:artist:0g3NiCRhEv7M4SEDMrpItN"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 246000,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205680"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/0LAOGIAFvEnMnzrO5oaAb5"
+      },
+      "href": "https://api.spotify.com/v1/tracks/0LAOGIAFvEnMnzrO5oaAb5",
+      "id": "0LAOGIAFvEnMnzrO5oaAb5",
+      "is_local": false,
+      "name": "Reviver - Totally Enormous Extinct Dinosaurs Remix",
+      "popularity": 52,
+      "preview_url": "https://p.scdn.co/mp3-preview/d6a1c15940e615a31f4b849651ce74824e2af5e8?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:0LAOGIAFvEnMnzrO5oaAb5"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6qgnBH6iDM91ipVXv28OMu"
+            },
+            "href": "https://api.spotify.com/v1/artists/6qgnBH6iDM91ipVXv28OMu",
+            "id": "6qgnBH6iDM91ipVXv28OMu",
+            "name": "KAYTRANADA",
+            "type": "artist",
+            "uri": "spotify:artist:6qgnBH6iDM91ipVXv28OMu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6JD4Qerb8IcaAzFgpFw0sa"
+        },
+        "href": "https://api.spotify.com/v1/albums/6JD4Qerb8IcaAzFgpFw0sa",
+        "id": "6JD4Qerb8IcaAzFgpFw0sa",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2733016bbbbdf0825d3e4dc9aee",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e023016bbbbdf0825d3e4dc9aee",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048513016bbbbdf0825d3e4dc9aee",
+            "width": 64
+          }
+        ],
+        "name": "99.9%",
+        "release_date": "2016-05-06",
+        "release_date_precision": "day",
+        "total_tracks": 15,
+        "type": "album",
+        "uri": "spotify:album:6JD4Qerb8IcaAzFgpFw0sa"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6qgnBH6iDM91ipVXv28OMu"
+          },
+          "href": "https://api.spotify.com/v1/artists/6qgnBH6iDM91ipVXv28OMu",
+          "id": "6qgnBH6iDM91ipVXv28OMu",
+          "name": "KAYTRANADA",
+          "type": "artist",
+          "uri": "spotify:artist:6qgnBH6iDM91ipVXv28OMu"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5SyCTZ8X8YQCI0J1VRp4iC"
+          },
+          "href": "https://api.spotify.com/v1/artists/5SyCTZ8X8YQCI0J1VRp4iC",
+          "id": "5SyCTZ8X8YQCI0J1VRp4iC",
+          "name": "Phonte",
+          "type": "artist",
+          "uri": "spotify:artist:5SyCTZ8X8YQCI0J1VRp4iC"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 218240,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBBKS1600018"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/11jR36qzNpUnQ2YbMrru1p"
+      },
+      "href": "https://api.spotify.com/v1/tracks/11jR36qzNpUnQ2YbMrru1p",
+      "id": "11jR36qzNpUnQ2YbMrru1p",
+      "is_local": false,
+      "name": "ONE TOO MANY",
+      "popularity": 46,
+      "preview_url": "https://p.scdn.co/mp3-preview/b88ad6d50e810df88f8c977736aef1a94930fb47?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 7,
+      "type": "track",
+      "uri": "spotify:track:11jR36qzNpUnQ2YbMrru1p"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0SFtIrRytNI4kcf93Tbhdf"
+        },
+        "href": "https://api.spotify.com/v1/albums/0SFtIrRytNI4kcf93Tbhdf",
+        "id": "0SFtIrRytNI4kcf93Tbhdf",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a871bc3a84418ad1240a5d4e",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a871bc3a84418ad1240a5d4e",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a871bc3a84418ad1240a5d4e",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 2 (February 2 - October 15 2021)",
+        "release_date": "2021-11-19",
+        "release_date_precision": "day",
+        "total_tracks": 16,
+        "type": "album",
+        "uri": "spotify:album:0SFtIrRytNI4kcf93Tbhdf"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 250291,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2100378"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1uyQNwG1sFl7etjFTEHlQp"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1uyQNwG1sFl7etjFTEHlQp",
+      "id": "1uyQNwG1sFl7etjFTEHlQp",
+      "is_local": false,
+      "name": "Faisal (envelops me)",
+      "popularity": 55,
+      "preview_url": "https://p.scdn.co/mp3-preview/1195ac049c8e184d166c11416353dfa7d9a19b84?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 9,
+      "type": "track",
+      "uri": "spotify:track:1uyQNwG1sFl7etjFTEHlQp"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/7xni0tZQ8q2rTHkIeBYr1Y"
+        },
+        "href": "https://api.spotify.com/v1/albums/7xni0tZQ8q2rTHkIeBYr1Y",
+        "id": "7xni0tZQ8q2rTHkIeBYr1Y",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2733df0f9ce9536ac74c7aa4b98",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e023df0f9ce9536ac74c7aa4b98",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048513df0f9ce9536ac74c7aa4b98",
+            "width": 64
+          }
+        ],
+        "name": "Danielle (smile on my face)",
+        "release_date": "2022-09-14",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:7xni0tZQ8q2rTHkIeBYr1Y"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 201230,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "GBAHS2201033"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/2sLVs5iX0osogh4jcsAJkv"
+      },
+      "href": "https://api.spotify.com/v1/tracks/2sLVs5iX0osogh4jcsAJkv",
+      "id": "2sLVs5iX0osogh4jcsAJkv",
+      "is_local": false,
+      "name": "Danielle (smile on my face)",
+      "popularity": 72,
+      "preview_url": "https://p.scdn.co/mp3-preview/40db3affef1f922de542f146621f5155ac05c074?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:2sLVs5iX0osogh4jcsAJkv"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6vN8o7jyIAJvFPqC0vxxmm"
+        },
+        "href": "https://api.spotify.com/v1/albums/6vN8o7jyIAJvFPqC0vxxmm",
+        "id": "6vN8o7jyIAJvFPqC0vxxmm",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27356c393fab9a517cad09be7de",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0256c393fab9a517cad09be7de",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485156c393fab9a517cad09be7de",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 3 (January 1 - September 9 2022)",
+        "release_date": "2022-10-28",
+        "release_date_precision": "day",
+        "total_tracks": 13,
+        "type": "album",
+        "uri": "spotify:album:6vN8o7jyIAJvFPqC0vxxmm"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 238829,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201029"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5qJGp0cDrsOoRZOn75K6Y0"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5qJGp0cDrsOoRZOn75K6Y0",
+      "id": "5qJGp0cDrsOoRZOn75K6Y0",
+      "is_local": false,
+      "name": "Kammy (like i do)",
+      "popularity": 65,
+      "preview_url": "https://p.scdn.co/mp3-preview/a73494a7067ed82fc43ec776583358de9e9b5914?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 4,
+      "type": "track",
+      "uri": "spotify:track:5qJGp0cDrsOoRZOn75K6Y0"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6vN8o7jyIAJvFPqC0vxxmm"
+        },
+        "href": "https://api.spotify.com/v1/albums/6vN8o7jyIAJvFPqC0vxxmm",
+        "id": "6vN8o7jyIAJvFPqC0vxxmm",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27356c393fab9a517cad09be7de",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0256c393fab9a517cad09be7de",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485156c393fab9a517cad09be7de",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 3 (January 1 - September 9 2022)",
+        "release_date": "2022-10-28",
+        "release_date_precision": "day",
+        "total_tracks": 13,
+        "type": "album",
+        "uri": "spotify:album:6vN8o7jyIAJvFPqC0vxxmm"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 250702,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201028"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/67uX1e9gIoumz0U8ayaOiO"
+      },
+      "href": "https://api.spotify.com/v1/tracks/67uX1e9gIoumz0U8ayaOiO",
+      "id": "67uX1e9gIoumz0U8ayaOiO",
+      "is_local": false,
+      "name": "Delilah (pull me out of this)",
+      "popularity": 69,
+      "preview_url": "https://p.scdn.co/mp3-preview/fef5d52bd1f5ab14809ed022f06a2f0cda0f031a?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 3,
+      "type": "track",
+      "uri": "spotify:track:67uX1e9gIoumz0U8ayaOiO"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+            },
+            "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+            "id": "4oLeXFyACqeem2VImYeBFe",
+            "name": "Fred again..",
+            "type": "artist",
+            "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6vN8o7jyIAJvFPqC0vxxmm"
+        },
+        "href": "https://api.spotify.com/v1/albums/6vN8o7jyIAJvFPqC0vxxmm",
+        "id": "6vN8o7jyIAJvFPqC0vxxmm",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b27356c393fab9a517cad09be7de",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e0256c393fab9a517cad09be7de",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d0000485156c393fab9a517cad09be7de",
+            "width": 64
+          }
+        ],
+        "name": "Actual Life 3 (January 1 - September 9 2022)",
+        "release_date": "2022-10-28",
+        "release_date_precision": "day",
+        "total_tracks": 13,
+        "type": "album",
+        "uri": "spotify:album:6vN8o7jyIAJvFPqC0vxxmm"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+          },
+          "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+          "id": "4oLeXFyACqeem2VImYeBFe",
+          "name": "Fred again..",
+          "type": "artist",
+          "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 210125,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBAHS2201027"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/7lCNgJUnROqgN9zIK0lx6a"
+      },
+      "href": "https://api.spotify.com/v1/tracks/7lCNgJUnROqgN9zIK0lx6a",
+      "id": "7lCNgJUnROqgN9zIK0lx6a",
+      "is_local": false,
+      "name": "Eyelar (shutters)",
+      "popularity": 65,
+      "preview_url": "https://p.scdn.co/mp3-preview/1ac3ec945d940a701baa885b1f7503ccce40eb48?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:7lCNgJUnROqgN9zIK0lx6a"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1Ma3pJzPIrAyYPNRkp3SUF"
+            },
+            "href": "https://api.spotify.com/v1/artists/1Ma3pJzPIrAyYPNRkp3SUF",
+            "id": "1Ma3pJzPIrAyYPNRkp3SUF",
+            "name": "Ross from Friends",
+            "type": "artist",
+            "uri": "spotify:artist:1Ma3pJzPIrAyYPNRkp3SUF"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6c94J2yum9wHxmbSB27YXE"
+        },
+        "href": "https://api.spotify.com/v1/albums/6c94J2yum9wHxmbSB27YXE",
+        "id": "6c94J2yum9wHxmbSB27YXE",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273088d99c85e6de4f30b39679c",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02088d99c85e6de4f30b39679c",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851088d99c85e6de4f30b39679c",
+            "width": 64
+          }
+        ],
+        "name": "You'll Understand",
+        "release_date": "2017-02-10",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:6c94J2yum9wHxmbSB27YXE"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1Ma3pJzPIrAyYPNRkp3SUF"
+          },
+          "href": "https://api.spotify.com/v1/artists/1Ma3pJzPIrAyYPNRkp3SUF",
+          "id": "1Ma3pJzPIrAyYPNRkp3SUF",
+          "name": "Ross from Friends",
+          "type": "artist",
+          "uri": "spotify:artist:1Ma3pJzPIrAyYPNRkp3SUF"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 365968,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "UKA2G1608006"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/3mNXKbWX8ZAL8AW97dnoLq"
+      },
+      "href": "https://api.spotify.com/v1/tracks/3mNXKbWX8ZAL8AW97dnoLq",
+      "id": "3mNXKbWX8ZAL8AW97dnoLq",
+      "is_local": false,
+      "name": "Bootman",
+      "popularity": 44,
+      "preview_url": "https://p.scdn.co/mp3-preview/a7f323c73ca25bce33aad2aef6d20eecaa23223f?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 3,
+      "type": "track",
+      "uri": "spotify:track:3mNXKbWX8ZAL8AW97dnoLq"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+            },
+            "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+            "id": "5gqoUf9vKKv96b1c0GBKwu",
+            "name": "Dusky",
+            "type": "artist",
+            "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6QEnHZniqvybsckdyptQql"
+        },
+        "href": "https://api.spotify.com/v1/albums/6QEnHZniqvybsckdyptQql",
+        "id": "6QEnHZniqvybsckdyptQql",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2737a9e1bfb1e953cab106ac9e1",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e027a9e1bfb1e953cab106ac9e1",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048517a9e1bfb1e953cab106ac9e1",
+            "width": 64
+          }
+        ],
+        "name": "Pressure",
+        "release_date": "2022-10-07",
+        "release_date_precision": "day",
+        "total_tracks": 11,
+        "type": "album",
+        "uri": "spotify:album:6QEnHZniqvybsckdyptQql"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5gqoUf9vKKv96b1c0GBKwu"
+          },
+          "href": "https://api.spotify.com/v1/artists/5gqoUf9vKKv96b1c0GBKwu",
+          "id": "5gqoUf9vKKv96b1c0GBKwu",
+          "name": "Dusky",
+          "type": "artist",
+          "uri": "spotify:artist:5gqoUf9vKKv96b1c0GBKwu"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 215222,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBEWA2205641"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/4xoYQAad9OYlNy7cASMNuS"
+      },
+      "href": "https://api.spotify.com/v1/tracks/4xoYQAad9OYlNy7cASMNuS",
+      "id": "4xoYQAad9OYlNy7cASMNuS",
+      "is_local": false,
+      "name": "Rollers",
+      "popularity": 29,
+      "preview_url": "https://p.scdn.co/mp3-preview/d729a369beb3c9a212a0ecbbf33e310dedb1f57c?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 7,
+      "type": "track",
+      "uri": "spotify:track:4xoYQAad9OYlNy7cASMNuS"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/5fMUXHkw8R8eOP2RNVYEZX"
+            },
+            "href": "https://api.spotify.com/v1/artists/5fMUXHkw8R8eOP2RNVYEZX",
+            "id": "5fMUXHkw8R8eOP2RNVYEZX",
+            "name": "Diplo",
+            "type": "artist",
+            "uri": "spotify:artist:5fMUXHkw8R8eOP2RNVYEZX"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4CA8PTrbq1l5IgyvBA2JSV"
+            },
+            "href": "https://api.spotify.com/v1/artists/4CA8PTrbq1l5IgyvBA2JSV",
+            "id": "4CA8PTrbq1l5IgyvBA2JSV",
+            "name": "Paul Woolford",
+            "type": "artist",
+            "uri": "spotify:artist:4CA8PTrbq1l5IgyvBA2JSV"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0Fb9qTWnjsB90xH3zWr4oa"
+            },
+            "href": "https://api.spotify.com/v1/artists/0Fb9qTWnjsB90xH3zWr4oa",
+            "id": "0Fb9qTWnjsB90xH3zWr4oa",
+            "name": "Kareen Lomax",
+            "type": "artist",
+            "uri": "spotify:artist:0Fb9qTWnjsB90xH3zWr4oa"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2pNtsyHd2CL7XM6PtwoOyG"
+        },
+        "href": "https://api.spotify.com/v1/albums/2pNtsyHd2CL7XM6PtwoOyG",
+        "id": "2pNtsyHd2CL7XM6PtwoOyG",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2738cfebe40bb99af0a25537788",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e028cfebe40bb99af0a25537788",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048518cfebe40bb99af0a25537788",
+            "width": 64
+          }
+        ],
+        "name": "Promises",
+        "release_date": "2021-09-28",
+        "release_date_precision": "day",
+        "total_tracks": 1,
+        "type": "album",
+        "uri": "spotify:album:2pNtsyHd2CL7XM6PtwoOyG"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5fMUXHkw8R8eOP2RNVYEZX"
+          },
+          "href": "https://api.spotify.com/v1/artists/5fMUXHkw8R8eOP2RNVYEZX",
+          "id": "5fMUXHkw8R8eOP2RNVYEZX",
+          "name": "Diplo",
+          "type": "artist",
+          "uri": "spotify:artist:5fMUXHkw8R8eOP2RNVYEZX"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4CA8PTrbq1l5IgyvBA2JSV"
+          },
+          "href": "https://api.spotify.com/v1/artists/4CA8PTrbq1l5IgyvBA2JSV",
+          "id": "4CA8PTrbq1l5IgyvBA2JSV",
+          "name": "Paul Woolford",
+          "type": "artist",
+          "uri": "spotify:artist:4CA8PTrbq1l5IgyvBA2JSV"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0Fb9qTWnjsB90xH3zWr4oa"
+          },
+          "href": "https://api.spotify.com/v1/artists/0Fb9qTWnjsB90xH3zWr4oa",
+          "id": "0Fb9qTWnjsB90xH3zWr4oa",
+          "name": "Kareen Lomax",
+          "type": "artist",
+          "uri": "spotify:artist:0Fb9qTWnjsB90xH3zWr4oa"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 201176,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USZ4V2100192"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/50YQaQXog18lS11wGCl77u"
+      },
+      "href": "https://api.spotify.com/v1/tracks/50YQaQXog18lS11wGCl77u",
+      "id": "50YQaQXog18lS11wGCl77u",
+      "is_local": false,
+      "name": "Promises",
+      "popularity": 50,
+      "preview_url": "https://p.scdn.co/mp3-preview/a44d6ebaf77727f26095991c81b295543bac345b?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:50YQaQXog18lS11wGCl77u"
+    },
+    {
+      "album": {
+        "album_type": "ALBUM",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0CkbPVBpOwwz9NPPglFKyq"
+            },
+            "href": "https://api.spotify.com/v1/artists/0CkbPVBpOwwz9NPPglFKyq",
+            "id": "0CkbPVBpOwwz9NPPglFKyq",
+            "name": "RAY BLK",
+            "type": "artist",
+            "uri": "spotify:artist:0CkbPVBpOwwz9NPPglFKyq"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2A9YfiOYh4jJ7qsLeUdnDM"
+        },
+        "href": "https://api.spotify.com/v1/albums/2A9YfiOYh4jJ7qsLeUdnDM",
+        "id": "2A9YfiOYh4jJ7qsLeUdnDM",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273456f28858603774693ccd632",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02456f28858603774693ccd632",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851456f28858603774693ccd632",
+            "width": 64
+          }
+        ],
+        "name": "Durt",
+        "release_date": "2016-10-27",
+        "release_date_precision": "day",
+        "total_tracks": 7,
+        "type": "album",
+        "uri": "spotify:album:2A9YfiOYh4jJ7qsLeUdnDM"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0CkbPVBpOwwz9NPPglFKyq"
+          },
+          "href": "https://api.spotify.com/v1/artists/0CkbPVBpOwwz9NPPglFKyq",
+          "id": "0CkbPVBpOwwz9NPPglFKyq",
+          "name": "RAY BLK",
+          "type": "artist",
+          "uri": "spotify:artist:0CkbPVBpOwwz9NPPglFKyq"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2SrSdSvpminqmStGELCSNd"
+          },
+          "href": "https://api.spotify.com/v1/artists/2SrSdSvpminqmStGELCSNd",
+          "id": "2SrSdSvpminqmStGELCSNd",
+          "name": "Stormzy",
+          "type": "artist",
+          "uri": "spotify:artist:2SrSdSvpminqmStGELCSNd"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 271956,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "FR2X41642772"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5IeuKkd8EE5prwJX77iW03"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5IeuKkd8EE5prwJX77iW03",
+      "id": "5IeuKkd8EE5prwJX77iW03",
+      "is_local": false,
+      "name": "My Hood",
+      "popularity": 45,
+      "preview_url": "https://p.scdn.co/mp3-preview/af953907161339f405626311f5b8b2bd09116d0f?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 6,
+      "type": "track",
+      "uri": "spotify:track:5IeuKkd8EE5prwJX77iW03"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6nxWCVXbOlEVRexSbLsTer"
+            },
+            "href": "https://api.spotify.com/v1/artists/6nxWCVXbOlEVRexSbLsTer",
+            "id": "6nxWCVXbOlEVRexSbLsTer",
+            "name": "Flume",
+            "type": "artist",
+            "uri": "spotify:artist:6nxWCVXbOlEVRexSbLsTer"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/2NUSMc4rQ9jjUFE3PnhKBO"
+        },
+        "href": "https://api.spotify.com/v1/albums/2NUSMc4rQ9jjUFE3PnhKBO",
+        "id": "2NUSMc4rQ9jjUFE3PnhKBO",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2739395c17791d868238377273a",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e029395c17791d868238377273a",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048519395c17791d868238377273a",
+            "width": 64
+          }
+        ],
+        "name": "Skin Companion EP II",
+        "release_date": "2017-02-17",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:2NUSMc4rQ9jjUFE3PnhKBO"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6nxWCVXbOlEVRexSbLsTer"
+          },
+          "href": "https://api.spotify.com/v1/artists/6nxWCVXbOlEVRexSbLsTer",
+          "id": "6nxWCVXbOlEVRexSbLsTer",
+          "name": "Flume",
+          "type": "artist",
+          "uri": "spotify:artist:6nxWCVXbOlEVRexSbLsTer"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5W10uJRsbt9bROJDKoI1Wn"
+          },
+          "href": "https://api.spotify.com/v1/artists/5W10uJRsbt9bROJDKoI1Wn",
+          "id": "5W10uJRsbt9bROJDKoI1Wn",
+          "name": "Moses Sumney",
+          "type": "artist",
+          "uri": "spotify:artist:5W10uJRsbt9bROJDKoI1Wn"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 259176,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "AUFF01700018"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/71CPVF1Z2fWQz4fMfpGsXC"
+      },
+      "href": "https://api.spotify.com/v1/tracks/71CPVF1Z2fWQz4fMfpGsXC",
+      "id": "71CPVF1Z2fWQz4fMfpGsXC",
+      "is_local": false,
+      "name": "Weekend",
+      "popularity": 35,
+      "preview_url": "https://p.scdn.co/mp3-preview/c16bc45ec58b2d6400625a0c9b91cbb1af030562?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:71CPVF1Z2fWQz4fMfpGsXC"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/73A3bLnfnz5BoQjb4gNCga"
+            },
+            "href": "https://api.spotify.com/v1/artists/73A3bLnfnz5BoQjb4gNCga",
+            "id": "73A3bLnfnz5BoQjb4gNCga",
+            "name": "Bicep",
+            "type": "artist",
+            "uri": "spotify:artist:73A3bLnfnz5BoQjb4gNCga"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6ZgM0jM6nRUlK6wRXEONVc"
+        },
+        "href": "https://api.spotify.com/v1/albums/6ZgM0jM6nRUlK6wRXEONVc",
+        "id": "6ZgM0jM6nRUlK6wRXEONVc",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273a52a69cf3de74cbc7f16f2a8",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02a52a69cf3de74cbc7f16f2a8",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851a52a69cf3de74cbc7f16f2a8",
+            "width": 64
+          }
+        ],
+        "name": "Apricots",
+        "release_date": "2020-10-06",
+        "release_date_precision": "day",
+        "total_tracks": 2,
+        "type": "album",
+        "uri": "spotify:album:6ZgM0jM6nRUlK6wRXEONVc"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/73A3bLnfnz5BoQjb4gNCga"
+          },
+          "href": "https://api.spotify.com/v1/artists/73A3bLnfnz5BoQjb4gNCga",
+          "id": "73A3bLnfnz5BoQjb4gNCga",
+          "name": "Bicep",
+          "type": "artist",
+          "uri": "spotify:artist:73A3bLnfnz5BoQjb4gNCga"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 246506,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBCFB2000317"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/73X9X7kDgsm4YeHpc8prf6"
+      },
+      "href": "https://api.spotify.com/v1/tracks/73X9X7kDgsm4YeHpc8prf6",
+      "id": "73X9X7kDgsm4YeHpc8prf6",
+      "is_local": false,
+      "name": "Apricots",
+      "popularity": 52,
+      "preview_url": "https://p.scdn.co/mp3-preview/b223277b823fa66ab8c28630b6770b46d7e5d0d0?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:73X9X7kDgsm4YeHpc8prf6"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/1WgXqy2Dd70QQOU7Ay074N"
+            },
+            "href": "https://api.spotify.com/v1/artists/1WgXqy2Dd70QQOU7Ay074N",
+            "id": "1WgXqy2Dd70QQOU7Ay074N",
+            "name": "AURORA",
+            "type": "artist",
+            "uri": "spotify:artist:1WgXqy2Dd70QQOU7Ay074N"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6kMFIRSHhvcwczeyyYqDMb"
+        },
+        "href": "https://api.spotify.com/v1/albums/6kMFIRSHhvcwczeyyYqDMb",
+        "id": "6kMFIRSHhvcwczeyyYqDMb",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b273f26cea9588f13dacc69378d8",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e02f26cea9588f13dacc69378d8",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d00004851f26cea9588f13dacc69378d8",
+            "width": 64
+          }
+        ],
+        "name": "Queendom (Remixes)",
+        "release_date": "2018-06-29",
+        "release_date_precision": "day",
+        "total_tracks": 3,
+        "type": "album",
+        "uri": "spotify:album:6kMFIRSHhvcwczeyyYqDMb"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1WgXqy2Dd70QQOU7Ay074N"
+          },
+          "href": "https://api.spotify.com/v1/artists/1WgXqy2Dd70QQOU7Ay074N",
+          "id": "1WgXqy2Dd70QQOU7Ay074N",
+          "name": "AURORA",
+          "type": "artist",
+          "uri": "spotify:artist:1WgXqy2Dd70QQOU7Ay074N"
+        },
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7nc2JTIfR3eZwXeq3pbwt2"
+          },
+          "href": "https://api.spotify.com/v1/artists/7nc2JTIfR3eZwXeq3pbwt2",
+          "id": "7nc2JTIfR3eZwXeq3pbwt2",
+          "name": "B.Traits",
+          "type": "artist",
+          "uri": "spotify:artist:7nc2JTIfR3eZwXeq3pbwt2"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 503786,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBUM71802864"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/1ObfZmvPZcdowxfaR9qFUS"
+      },
+      "href": "https://api.spotify.com/v1/tracks/1ObfZmvPZcdowxfaR9qFUS",
+      "id": "1ObfZmvPZcdowxfaR9qFUS",
+      "is_local": false,
+      "name": "Queendom - B.Traits Remix",
+      "popularity": 17,
+      "preview_url": "https://p.scdn.co/mp3-preview/d82bf52001e61f6453de4ee2659f685292330582?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:1ObfZmvPZcdowxfaR9qFUS"
+    },
+    {
+      "album": {
+        "album_type": "SINGLE",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/6TshTCYwh9ySzOO6Jy4Ux2"
+            },
+            "href": "https://api.spotify.com/v1/artists/6TshTCYwh9ySzOO6Jy4Ux2",
+            "id": "6TshTCYwh9ySzOO6Jy4Ux2",
+            "name": "Maya Jane Coles",
+            "type": "artist",
+            "uri": "spotify:artist:6TshTCYwh9ySzOO6Jy4Ux2"
+          }
+        ],
+        "available_markets": [],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/0DECxh5mdTBhB2Rw9qE7UI"
+        },
+        "href": "https://api.spotify.com/v1/albums/0DECxh5mdTBhB2Rw9qE7UI",
+        "id": "0DECxh5mdTBhB2Rw9qE7UI",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2735fc235dac602275bcfb0c869",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67616d00001e025fc235dac602275bcfb0c869",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab67616d000048515fc235dac602275bcfb0c869",
+            "width": 64
+          }
+        ],
+        "name": "What They Say EP",
+        "release_date": "2010-09-22",
+        "release_date_precision": "day",
+        "total_tracks": 4,
+        "type": "album",
+        "uri": "spotify:album:0DECxh5mdTBhB2Rw9qE7UI"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6TshTCYwh9ySzOO6Jy4Ux2"
+          },
+          "href": "https://api.spotify.com/v1/artists/6TshTCYwh9ySzOO6Jy4Ux2",
+          "id": "6TshTCYwh9ySzOO6Jy4Ux2",
+          "name": "Maya Jane Coles",
+          "type": "artist",
+          "uri": "spotify:artist:6TshTCYwh9ySzOO6Jy4Ux2"
+        }
+      ],
+      "available_markets": [],
+      "disc_number": 1,
+      "duration_ms": 400115,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "GBKPL1417035"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/5S7Y5HgQ2HPqiCVkKylT2r"
+      },
+      "href": "https://api.spotify.com/v1/tracks/5S7Y5HgQ2HPqiCVkKylT2r",
+      "id": "5S7Y5HgQ2HPqiCVkKylT2r",
+      "is_local": false,
+      "name": "What They Say",
+      "popularity": 44,
+      "preview_url": "https://p.scdn.co/mp3-preview/1fe80f31d2914376562a7b2b896d63d5ae15c9ec?cid=230c2ac940f14f9aa4294af862300e9b",
+      "track_number": 1,
+      "type": "track",
+      "uri": "spotify:track:5S7Y5HgQ2HPqiCVkKylT2r"
+    }
+  ],
+  "limit": 50,
+  "next": null,
+  "offset": 0,
+  "previous": null,
+  "total": 50
+}

--- a/tests/unit/clients/spotify/test__track.py
+++ b/tests/unit/clients/spotify/test__track.py
@@ -10,7 +10,7 @@ import pytest
 from requests import HTTPError
 
 from tests.conftest import assert_mock_requests_request_history
-from wg_utilities.clients.spotify import Album, Artist, SpotifyClient, Track
+from wg_utilities.clients.spotify import Album, AlbumType, Artist, SpotifyClient, Track
 
 if TYPE_CHECKING:
     from requests_mock import Mocker
@@ -21,7 +21,7 @@ def test_instantiation(spotify_client: SpotifyClient) -> None:
     track = Track.from_json_response(
         {
             "album": {
-                "album_type": "album",
+                "album_type": AlbumType("album"),
                 "artists": [
                     {
                         "external_urls": {

--- a/tests/unit/clients/spotify/test__user.py
+++ b/tests/unit/clients/spotify/test__user.py
@@ -600,6 +600,37 @@ def test_top_tracks_property(
     )
 
 
+@pytest.mark.parametrize(
+    "time_range",
+    ["short_term", "medium_term", "long_term"],
+)
+def test_get_top_tracks(
+    spotify_user: User,
+    mock_requests: Mocker,
+    spotify_client: SpotifyClient,
+    live_jwt_token: str,
+    time_range: Literal["short_term", "medium_term", "long_term"],
+) -> None:
+    """Test that `top_tracks` property makes the expected request."""
+    top_tracks = spotify_user.get_top_tracks(time_range=time_range, limit=50)
+
+    assert len(top_tracks) == 50
+    assert isinstance(top_tracks, tuple)
+    assert all(isinstance(track, Track) for track in top_tracks)
+    assert all(track.spotify_client == spotify_client for track in top_tracks)
+
+    assert_mock_requests_request_history(
+        mock_requests.request_history,
+        [
+            {
+                "url": f"{SpotifyClient.BASE_URL}/me/top/tracks?time_range={time_range}&limit=50",
+                "method": "GET",
+                "headers": {"Authorization": f"Bearer {live_jwt_token}"},
+            },
+        ],
+    )
+
+
 def test_tracks_property(
     spotify_user: User,
     mock_requests: Mocker,

--- a/wg_utilities/clients/_spotify_types.py
+++ b/wg_utilities/clients/_spotify_types.py
@@ -7,8 +7,9 @@ are used for type hinting and to make the code more readable.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from logging import DEBUG, getLogger
-from typing import TYPE_CHECKING, Literal, TypeAlias, final
+from typing import TYPE_CHECKING, Literal, Self, TypeAlias, final
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -64,6 +65,25 @@ class SpotifyNamedEntityJson(SpotifyBaseEntityJson):
 # <editor-fold desc="Album Objects">
 
 
+class AlbumType(StrEnum):
+    """Enum for the different types of album Spotify supports."""
+
+    SINGLE = "single"
+    ALBUM = "album"
+    COMPILATION = "compilation"
+    EP = "ep"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        value = str(value).casefold()
+
+        for member in cls:
+            if member.value == value:
+                return member
+
+        return None
+
+
 class AlbumSummaryJson(SpotifyNamedEntityJson, total=False):
     """Type info for Spotify albums in tracks.
 
@@ -72,14 +92,7 @@ class AlbumSummaryJson(SpotifyNamedEntityJson, total=False):
     """
 
     album_group: Literal["album", "single", "compilation", "appears_on"]
-    album_type: Literal[
-        "single",
-        "album",
-        "compilation",
-        "SINGLE",
-        "ALBUM",
-        "COMPILATION",
-    ]
+    album_type: AlbumType
     artists: list[ArtistSummaryJson]
     available_markets: list[str]
     images: list[Image]

--- a/wg_utilities/clients/_spotify_types.py
+++ b/wg_utilities/clients/_spotify_types.py
@@ -72,6 +72,7 @@ class AlbumType(StrEnum):
     ALBUM = "album"
     COMPILATION = "compilation"
     EP = "ep"
+    AUDIOBOOK = "audiobook"
 
     @classmethod
     def _missing_(cls, value: object) -> Self | None:

--- a/wg_utilities/clients/spotify.py
+++ b/wg_utilities/clients/spotify.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
-from enum import StrEnum
 from http import HTTPStatus
 from json import dumps
 from logging import DEBUG, getLogger
@@ -28,6 +27,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from wg_utilities.clients._spotify_types import (
     AlbumSummaryJson,
+    AlbumType,
     AnyPaginatedResponse,
     ArtistSummaryJson,
     DeviceJson,
@@ -66,14 +66,6 @@ class ParsedSearchResponse(TypedDict):
     artists: NotRequired[list[Artist]]
     playlists: NotRequired[list[Playlist]]
     tracks: NotRequired[list[Track]]
-
-
-class AlbumType(StrEnum):
-    """Enum for the different types of album Spotify supports."""
-
-    SINGLE = "single"
-    ALBUM = "album"
-    COMPILATION = "compilation"
 
 
 class Device(BaseModelWithConfig):
@@ -669,14 +661,7 @@ class Album(SpotifyEntity[AlbumSummaryJson]):
     """An album on Spotify."""
 
     album_group: Literal["album", "single", "compilation", "appears_on"] | None = None
-    album_type_str: Literal[
-        "single",
-        "album",
-        "compilation",
-        "SINGLE",
-        "ALBUM",
-        "COMPILATION",
-    ] = Field(alias="album_type")
+    album_type_str: AlbumType = Field(alias="album_type")
     artists_json: list[ArtistSummaryJson] = Field(alias="artists")
     available_markets: list[str]
     copyrights: list[dict[str, str]] | None = None
@@ -1265,6 +1250,25 @@ class User(SpotifyEntity[UserSummaryJson]):
             )
         ]
 
+    def get_top_tracks(
+        self, time_range: Literal["short_term", "medium_term", "long_term"] = "short_term"
+    ) -> tuple[Track, ...]:
+        """The top tracks for the user.
+
+        Returns:
+            tuple[Track]: the top tracks for the user
+        """
+        return tuple(
+            Track.from_json_response(
+                track_json,
+                spotify_client=self.spotify_client,
+            )
+            for track_json in self.spotify_client.get_items(
+                "/me/top/tracks",
+                params={"time_range": time_range},
+            )
+        )
+
     def save(self, entity: Album | Artist | Playlist | Track) -> None:
         """Save an entity to the user's library.
 
@@ -1610,3 +1614,17 @@ SpotifyEntity.model_rebuild()
 Album.model_rebuild()
 Artist.model_rebuild()
 Track.model_rebuild()
+
+
+__all__ = [
+    "Album",
+    "AlbumType",
+    "Artist",
+    "Device",
+    "Followers",
+    "Image",
+    "Playlist",
+    "SpotifyClient",
+    "Track",
+    "User",
+]

--- a/wg_utilities/clients/spotify.py
+++ b/wg_utilities/clients/spotify.py
@@ -1251,7 +1251,9 @@ class User(SpotifyEntity[UserSummaryJson]):
         ]
 
     def get_top_tracks(
-        self, time_range: Literal["short_term", "medium_term", "long_term"] = "short_term"
+        self,
+        time_range: Literal["short_term", "medium_term", "long_term"] = "short_term",
+        limit: int = 100,
     ) -> tuple[Track, ...]:
         """The top tracks for the user.
 
@@ -1266,6 +1268,7 @@ class User(SpotifyEntity[UserSummaryJson]):
             for track_json in self.spotify_client.get_items(
                 "/me/top/tracks",
                 params={"time_range": time_range},
+                hard_limit=limit,
             )
         )
 


### PR DESCRIPTION


---



- a322f66 | Add `get_top_tracks` method to Spotify client
- 004ba11 | Add limit argument
- 397d670 | Add UT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `AlbumType` enum for improved album type representation (SINGLE, ALBUM, COMPILATION, EP).
	- Added a `get_top_tracks` method to the `User` class for retrieving top tracks based on a specified time range.

- **Improvements**
	- Enhanced type safety by replacing string literals with the `AlbumType` enum in relevant classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->