### PR TITLE
Add method to remove playlist tracks to Spotify client

### DIFF
--- a/tests/unit/clients/spotify/conftest.py
+++ b/tests/unit/clients/spotify/conftest.py
@@ -221,7 +221,7 @@ def mock_requests_(mock_requests_root: Mocker) -> Mocker:
         json=get_flat_file_from_url,
     )
 
-    for method in ("put", "delete"):
+    for method in ("post", "put", "delete"):
         for entity_type in ("albums", "following", "tracks"):
             mock_requests_root.register_uri(
                 method,
@@ -241,16 +241,17 @@ def mock_requests_(mock_requests_root: Mocker) -> Mocker:
             reason=HTTPStatus.OK.phrase,
         )
 
-    mock_requests_root.post(
-        # Matches `/v1/playlists/<playlist id>/tracks`
-        compile_regex(
-            r"^https:\/\/api\.spotify\.com\/v1\/playlists/([a-z0-9]{22})/tracks",
-            flags=IGNORECASE,
-        ),
-        status_code=HTTPStatus.OK,
-        reason=HTTPStatus.OK.phrase,
-        json={"snapshot_id": "MTAsZDVmZjMjJhZTVmZjcxOGNlMA=="},
-    )
+        mock_requests_root.register_uri(
+            method,
+            # Matches `/v1/playlists/<playlist id>/tracks`
+            compile_regex(
+                r"^https:\/\/api\.spotify\.com\/v1\/playlists/([a-z0-9]{22})/tracks",
+                flags=IGNORECASE,
+            ),
+            status_code=HTTPStatus.OK,
+            reason=HTTPStatus.OK.phrase,
+            json={"snapshot_id": "MTAsZDVmZjMjJhZTVmZjcxOGNlMA=="},
+        )
 
     mock_requests_root.post(
         f"{SpotifyClient.BASE_URL}/users/worgarside/playlists",

--- a/wg_utilities/clients/spotify.py
+++ b/wg_utilities/clients/spotify.py
@@ -425,7 +425,7 @@ class SpotifyClient(OAuthClient[SpotifyEntityJson]):
         for chunk in chunk_list(list(tracks), 100):
             res = delete(
                 url,
-                json={"uris": [t.uri for t in chunk]},
+                json={"tracks": [{"uri": t.uri} for t in chunk]},
                 headers={
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {self.access_token}",


### PR DESCRIPTION


---



- 73e9a46 | Add method to remove playlist tracks to Spotify client
- 23c5ca8 | Fix request payload


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to remove tracks from a specified Spotify playlist, enhancing playlist management capabilities.
	- Improved access speed to user playlists by optimizing the retrieval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->